### PR TITLE
Fix/issue24

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,6 @@ This project is provided as-is for use with Proxmox VE and TrueNAS SCALE.
 
 ---
 
-**Version**: 2.0.14
-**Last Updated**: April 2, 2026
+**Version**: 2.0.15
+**Last Updated**: April 3, 2026
 **Compatibility**: Proxmox VE 8.x+, TrueNAS SCALE 25.10+

--- a/README.md
+++ b/README.md
@@ -324,6 +324,6 @@ This project is provided as-is for use with Proxmox VE and TrueNAS SCALE.
 
 ---
 
-**Version**: 2.0.13
-**Last Updated**: March 31, 2026
+**Version**: 2.0.14
+**Last Updated**: April 2, 2026
 **Compatibility**: Proxmox VE 8.x+, TrueNAS SCALE 25.10+

--- a/TrueNASPlugin.pm
+++ b/TrueNASPlugin.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 
 # Plugin Version
-our $VERSION = '2.0.14';
+our $VERSION = '2.0.15';
 # Highest Proxmox storage API version this plugin is validated against.
 our $TESTED_APIVER = 13;
 use JSON::PP qw(encode_json decode_json);
@@ -4472,12 +4472,9 @@ sub _free_image_iscsi {
     my $in_use = sub { my ($e)=@_; return ($e && $e =~ /in use/i) ? 1 : 0; };
     my $need_force_logout = 0;
     my $did_session_logout = 0;
-    my $scsi_teardown_done = 0;
 
     # Pre-teardown: remove this LUN's SCSI block device from the kernel before TrueNAS API calls.
     # The iSCSI TCP session stays open (needed for other LUNs), but the kernel device is released.
-    # After teardown succeeds, we pass force=true to TrueNAS delete calls to bypass the
-    # persistent-session check — the session no longer has any active I/O against this LUN.
     if (@scsi_devices_to_cleanup) {
         _log($scfg, 2, 'debug', "[TrueNAS] _free_image_iscsi: pre-teardown of " . scalar(@scsi_devices_to_cleanup) . " SCSI device(s) before API calls");
         my @device_paths;
@@ -4491,20 +4488,18 @@ sub _free_image_iscsi {
                 };
             }
         }
-        my $verified = _verify_devices_disconnected($scfg, \@device_paths);
+        _verify_devices_disconnected($scfg, \@device_paths);
         eval { run_command(['udevadm','settle'], outfunc => sub {}) };
         sleep(DEVICE_SETTLE_DELAY_S);
         @scsi_devices_to_cleanup = ();
-        # Only set flag when kernel confirms devices gone — gates force=true on API calls below
-        $scsi_teardown_done = $verified ? 1 : 0;
     }
 
     # 1) Delete targetextent mapping
-    # Pass force=true when SCSI teardown confirmed no active I/O against this LUN.
+    # Always pass force=true to bypass "target in use" checks from other cluster nodes' sessions.
     if ($tx && defined $tx->{id}) {
         my $id = $tx->{id};
         my $ok = eval {
-            _api_call($scfg,'iscsi.targetextent.delete',[ $id, $scsi_teardown_done ? JSON::PP::true : JSON::PP::false ]);
+            _api_call($scfg,'iscsi.targetextent.delete',[ $id, JSON::PP::true ]);
             1;
         };
         if (!$ok) {
@@ -4520,11 +4515,11 @@ sub _free_image_iscsi {
     }
 
     # 2) Delete extent (may still be mapped if step 1 failed)
-    # Pass force=true when SCSI teardown confirmed no active I/O against this LUN.
+    # Always pass force=true to bypass "target in use" checks from other cluster nodes' sessions.
     if ($extent && defined $extent->{id}) {
         my $eid = $extent->{id};
         my $ok = eval {
-            _api_call($scfg,'iscsi.extent.delete',[ $eid, JSON::PP::false, $scsi_teardown_done ? JSON::PP::true : JSON::PP::false ]);
+            _api_call($scfg,'iscsi.extent.delete',[ $eid, JSON::PP::false, JSON::PP::true ]);
             1;
         };
         if (!$ok) {
@@ -4572,7 +4567,7 @@ sub _free_image_iscsi {
         if ($tx && defined $tx->{id}) {
             my $id = $tx->{id};
             eval {
-                _api_call($scfg,'iscsi.targetextent.delete',[ $id, $scsi_teardown_done ? JSON::PP::true : JSON::PP::false ]);
+                _api_call($scfg,'iscsi.targetextent.delete',[ $id, JSON::PP::true ]);
             };
             if ($@) {
                 # In cluster environments, other nodes may have active sessions causing "in use" errors
@@ -4586,7 +4581,7 @@ sub _free_image_iscsi {
         if ($extent && defined $extent->{id}) {
             my $eid = $extent->{id};
             eval {
-                _api_call($scfg,'iscsi.extent.delete',[ $eid, JSON::PP::false, $scsi_teardown_done ? JSON::PP::true : JSON::PP::false ]);
+                _api_call($scfg,'iscsi.extent.delete',[ $eid, JSON::PP::false, JSON::PP::true ]);
             };
             if ($@) {
                 _log($scfg, 1, 'info', "[TrueNAS] _free_image_iscsi: could not delete extent id=$eid (may be in use by other cluster nodes)");

--- a/TrueNASPlugin.pm
+++ b/TrueNASPlugin.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 
 # Plugin Version
-our $VERSION = '2.0.13';
+our $VERSION = '2.0.14';
 # Highest Proxmox storage API version this plugin is validated against.
 our $TESTED_APIVER = 13;
 use JSON::PP qw(encode_json decode_json);
@@ -4442,29 +4442,7 @@ sub _free_image_iscsi {
         _log($scfg, 2, 'debug', "[TrueNAS] _free_image_iscsi: captured " . scalar(@scsi_devices_to_cleanup) . " SCSI device(s) for cleanup") if @scsi_devices_to_cleanup;
     }
 
-    # Best-effort: flush local multipath path of this WWID (ignore "not a multipath device")
-    if ($scfg->{use_multipath}) {
-        eval {
-            my ($dev) = $class->path($scfg, $volname, $storeid, undef);
-            if ($dev) {
-                my $leaf = Cwd::abs_path($dev);
-                my $wwid = '';
-                eval {
-                    PVE::Tools::run_command(
-                        ['/lib/udev/scsi_id','-g','-u','-d',$leaf],
-                        outfunc => sub { $wwid .= $_[0]; }, errfunc => sub {}
-                    );
-                };
-                chomp($wwid) if $wwid;
-                if ($wwid) {
-                    eval { PVE::Tools::run_command(['multipath','-f',$wwid], outfunc=>sub{}, errfunc=>sub{}) };
-                }
-            }
-        };
-        # ignore any multipath flush errors here
-    }
-
-    # Resolve target/extent/mapping on TrueNAS
+    # Resolve target/extent/mapping on TrueNAS (moved up: needed for WWID validation below)
     my $target_id = _resolve_target_id($scfg);
     my $extents = _tn_extents($scfg) // [];
     my $zvol_path_match = "zvol/$scfg->{dataset}/$zname";
@@ -4474,14 +4452,59 @@ sub _free_image_iscsi {
         ? grep { (($_->{target}//-1) == $target_id) && (($_->{extent}//-1) == $extent->{id}) } @$maps
         : ();
 
+    # Best-effort: flush the local multipath map for this LUN's WWID.
+    # Derive WWID directly from the TrueNAS extent NAA (already fetched above) rather than
+    # calling path() + scsi_id — scsi_id does not work reliably on DM devices (/dev/mapper/mpathX),
+    # and calling path() here would re-enter the login path on a volume being deleted.
+    # TrueNAS NAA format: "0x6589cfc..." → multipath WWID: "36589cfc..." (0x prefix → NAA-6 type byte 3)
+    if ($scfg->{use_multipath}) {
+        eval {
+            if ($extent && $extent->{naa} && $extent->{naa} =~ /^0x/i) {
+                (my $flush_wwid = lc($extent->{naa})) =~ s/^0x/3/;
+                _log($scfg, 2, 'debug', "[TrueNAS] _free_image_iscsi: flushing multipath map $flush_wwid");
+                eval { PVE::Tools::run_command(['multipath','-f',$flush_wwid], outfunc=>sub{}, errfunc=>sub{}) };
+            }
+            # If no extent or NAA missing/malformed: skip flush (cannot determine WWID safely)
+        };
+        # ignore any multipath flush errors here
+    }
+
     my $in_use = sub { my ($e)=@_; return ($e && $e =~ /in use/i) ? 1 : 0; };
     my $need_force_logout = 0;
+    my $did_session_logout = 0;
+    my $scsi_teardown_done = 0;
+
+    # Pre-teardown: remove this LUN's SCSI block device from the kernel before TrueNAS API calls.
+    # The iSCSI TCP session stays open (needed for other LUNs), but the kernel device is released.
+    # After teardown succeeds, we pass force=true to TrueNAS delete calls to bypass the
+    # persistent-session check — the session no longer has any active I/O against this LUN.
+    if (@scsi_devices_to_cleanup) {
+        _log($scfg, 2, 'debug', "[TrueNAS] _free_image_iscsi: pre-teardown of " . scalar(@scsi_devices_to_cleanup) . " SCSI device(s) before API calls");
+        my @device_paths;
+        for my $dev (@scsi_devices_to_cleanup) {
+            my $delete_path = "/sys/block/$dev/device/delete";
+            push @device_paths, $delete_path if -e $delete_path;
+            if (-e $delete_path && -w $delete_path) {
+                eval {
+                    _log($scfg, 2, 'debug', "[TrueNAS] _free_image_iscsi: deleting SCSI device $dev");
+                    if (open my $fh, '>', $delete_path) { print $fh "1"; close $fh; }
+                };
+            }
+        }
+        my $verified = _verify_devices_disconnected($scfg, \@device_paths);
+        eval { run_command(['udevadm','settle'], outfunc => sub {}) };
+        sleep(DEVICE_SETTLE_DELAY_S);
+        @scsi_devices_to_cleanup = ();
+        # Only set flag when kernel confirms devices gone — gates force=true on API calls below
+        $scsi_teardown_done = $verified ? 1 : 0;
+    }
 
     # 1) Delete targetextent mapping
+    # Pass force=true when SCSI teardown confirmed no active I/O against this LUN.
     if ($tx && defined $tx->{id}) {
         my $id = $tx->{id};
         my $ok = eval {
-            _api_call($scfg,'iscsi.targetextent.delete',[ $id ]);
+            _api_call($scfg,'iscsi.targetextent.delete',[ $id, $scsi_teardown_done ? JSON::PP::true : JSON::PP::false ]);
             1;
         };
         if (!$ok) {
@@ -4497,10 +4520,11 @@ sub _free_image_iscsi {
     }
 
     # 2) Delete extent (may still be mapped if step 1 failed)
+    # Pass force=true when SCSI teardown confirmed no active I/O against this LUN.
     if ($extent && defined $extent->{id}) {
         my $eid = $extent->{id};
         my $ok = eval {
-            _api_call($scfg,'iscsi.extent.delete',[ $eid ]);
+            _api_call($scfg,'iscsi.extent.delete',[ $eid, JSON::PP::false, $scsi_teardown_done ? JSON::PP::true : JSON::PP::false ]);
             1;
         };
         if (!$ok) {
@@ -4529,24 +4553,26 @@ sub _free_image_iscsi {
             $active_luns = scalar(@target_maps);
         };
 
-        # Only logout if this is the last LUN, or if we can't determine LUN count
-        # This prevents breaking multi-disk restore/creation operations
+        # Only logout if this is the last LUN (or unknown count) — full logout during a
+        # disk move would tear down the destination LUN's session mid-copy.
         if ($active_luns <= 1 || $@) {
             _log($scfg, 2, 'debug', "[TrueNAS] _free_image_iscsi: logging out to retry extent deletion (active LUNs: $active_luns)");
             _logout_target_all_portals($scfg);
-            # Wait for iSCSI session to fully disconnect before retrying deletion
             _log($scfg, 2, 'debug', "[TrueNAS] _free_image_iscsi: waiting for iSCSI session to disconnect");
-            sleep(DEVICE_SETTLE_DELAY_S);  # Reduced from 2s to 1s - modern systems settle faster
+            sleep(DEVICE_SETTLE_DELAY_S);
             eval { run_command(['udevadm','settle'], outfunc => sub {}) };
+            $did_session_logout = 1;
         } else {
-            _log($scfg, 2, 'debug', "[TrueNAS] _free_image_iscsi: skipping logout - $active_luns other LUNs active");
-            $need_force_logout = 0;  # Skip retry since we're not logging out
+            # Other LUNs active — do NOT logout entire target.
+            # Early per-LUN SCSI teardown should have released this LUN's reference.
+            # $need_force_logout stays 1 to trigger the retry block below without a session logout.
+            _log($scfg, 2, 'debug', "[TrueNAS] _free_image_iscsi: $active_luns LUNs active — retrying deletes without logout");
         }
         # Retry mapping delete
         if ($tx && defined $tx->{id}) {
             my $id = $tx->{id};
             eval {
-                _api_call($scfg,'iscsi.targetextent.delete',[ $id ]);
+                _api_call($scfg,'iscsi.targetextent.delete',[ $id, $scsi_teardown_done ? JSON::PP::true : JSON::PP::false ]);
             };
             if ($@) {
                 # In cluster environments, other nodes may have active sessions causing "in use" errors
@@ -4560,7 +4586,7 @@ sub _free_image_iscsi {
         if ($extent && defined $extent->{id}) {
             my $eid = $extent->{id};
             eval {
-                _api_call($scfg,'iscsi.extent.delete',[ $eid ]);
+                _api_call($scfg,'iscsi.extent.delete',[ $eid, JSON::PP::false, $scsi_teardown_done ? JSON::PP::true : JSON::PP::false ]);
             };
             if ($@) {
                 _log($scfg, 1, 'info', "[TrueNAS] _free_image_iscsi: could not delete extent id=$eid (may be in use by other cluster nodes)");
@@ -4568,44 +4594,14 @@ sub _free_image_iscsi {
         }
     }
 
-    # 4) CRITICAL: Ensure devices are fully disconnected BEFORE dataset deletion
-    # This fixes the race condition where dataset deletion fails with "busy" errors
-    # because the kernel still has active device references
-    if ($need_force_logout || @scsi_devices_to_cleanup) {
-        # Logout to disconnect iSCSI sessions
-        if ($need_force_logout) {
-            _log($scfg, 2, 'debug', "[TrueNAS] _free_image_iscsi: logging out before dataset deletion to prevent race condition");
-            _logout_target_all_portals($scfg);
+    # 4) Allow devices to settle before dataset deletion
+    if ($need_force_logout) {
+        if ($did_session_logout) {
+            # Session was disconnected in step 3 — give it a moment before dataset deletion
             sleep(DEVICE_SETTLE_DELAY_S);
         }
-
-        # Clean up orphaned SCSI device entries from kernel
-        # This must happen BEFORE dataset deletion to prevent "busy" errors
-        if (@scsi_devices_to_cleanup) {
-            _log($scfg, 2, 'debug', "[TrueNAS] _free_image_iscsi: cleaning up " . scalar(@scsi_devices_to_cleanup) . " SCSI device(s) before dataset deletion");
-            my @device_paths;
-            for my $dev (@scsi_devices_to_cleanup) {
-                my $delete_path = "/sys/block/$dev/device/delete";
-                push @device_paths, $delete_path if -e $delete_path;
-                if (-e $delete_path && -w $delete_path) {
-                    eval {
-                        _log($scfg, 2, 'debug', "[TrueNAS] _free_image_iscsi: deleting SCSI device $dev for LUN $lun");
-                        if (open my $fh, '>', $delete_path) {
-                            print $fh "1";
-                            close $fh;
-                        }
-                    };
-                    # Ignore errors - device may already be gone
-                }
-            }
-
-            # Verify devices are disconnected before proceeding
-            _verify_devices_disconnected($scfg, \@device_paths);
-        }
-
-        # Run udevadm settle to ensure kernel has processed all changes
         eval { run_command(['udevadm','settle'], outfunc => sub {}) };
-        $need_force_logout = 1;  # Mark that we need to handle reconnection later
+        $need_force_logout = 1;  # signal deferred cleanup: skip session rescan
     }
 
     # 5) Delete the zvol dataset using retry logic with exponential backoff
@@ -5401,7 +5397,11 @@ sub activate_volume {
 
     if ($mode eq 'iscsi') {
         _iscsi_login_all($scfg);
-        if ($scfg->{use_multipath}) { run_command(['multipath','-r'], outfunc => sub {}); }
+        if ($scfg->{use_multipath}) {
+            run_command(['multipath','-r'], outfunc => sub {});
+            eval { run_command(['udevadm','settle'], outfunc => sub {}) };
+            usleep(UDEV_SETTLE_TIMEOUT_US);
+        }
 
         # Wait for the specific LUN device to appear (up to ~20s, configurable)
         my $lun = $metadata;

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,14 @@
+truenas-proxmox-plugin (2.0.14+deb1) unstable; urgency=medium
+
+  * Fix disk move with multipath: SCSI teardown before TrueNAS delete APIs + force=true
+    to bypass persistent-session "in use" check (Issue #15)
+  * Fix multipath flush in free_image: derive WWID from extent NAA instead of scsi_id
+    on DM device — resolves zombie ##,## mpath entries after every disk move (Issue #15)
+  * Fix race window in activate_volume: add udevadm settle after multipath -r (Issue #15)
+  * Fix force-logout retry skipped during disk moves when active_luns >= 2 (Issue #15)
+
+ -- TrueNAS Proxmox Plugin Maintainers <noreply@github.com>  Wed, 02 Apr 2026 00:00:00 +0000
+
 truenas-proxmox-plugin (2.0.13+deb1) unstable; urgency=medium
 
   * Skip disruptive iSCSI rescan during allocation when sessions already active (Issue #15)

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+truenas-proxmox-plugin (2.0.15+deb1) unstable; urgency=medium
+
+  * Always force-delete iSCSI targetextent/extent in free_image to fix cluster
+    disk move failures when other nodes have active sessions (Issue #24)
+
+ -- TrueNAS Proxmox Plugin Maintainers <noreply@github.com>  Thu, 03 Apr 2026 00:00:00 +0000
+
 truenas-proxmox-plugin (2.0.14+deb1) unstable; urgency=medium
 
   * Fix disk move with multipath: SCSI teardown before TrueNAS delete APIs + force=true

--- a/wiki/Changelog.md
+++ b/wiki/Changelog.md
@@ -1,5 +1,19 @@
 # TrueNAS Plugin Changelog
 
+## Version 2.0.14 (April 2, 2026)
+
+### Bug Fixes
+
+- **Fix disk move with multipath — orphaned iSCSI extents on TrueNAS (GitHub issue #15)**: When moving a stopped VM's disk between storages with `use_multipath=1`, the plugin now tears down the source LUN's SCSI block device before calling TrueNAS delete APIs, and passes `force=true` to `iscsi.targetextent.delete` and `iscsi.extent.delete` once the kernel confirms no active I/O against that LUN. Previously, persistent iSCSI sessions caused TrueNAS to refuse deletion ("target is in use"), leaving orphaned extent/targetextent records and zombie `##,##` multipath devices after every move
+
+- **Fix multipath flush destroying destination device mid-copy (GitHub issue #15)**: The multipath map flush in `_free_image_iscsi` now derives the WWID directly from the TrueNAS extent NAA record (already fetched for deletion) rather than calling `path()` + `scsi_id` on the device path. `scsi_id` does not work reliably on DM devices (`/dev/mapper/mpathX`) and was silently returning empty, leaving zombie `##,##` DM entries after every disk move. The new approach also prevents flushing the wrong (destination) device during a concurrent disk move
+
+- **Fix race window between `multipath -r` and device access in `activate_volume` (GitHub issue #15)**: Added `udevadm settle` + 250ms grace period after `multipath -r` in `activate_volume` to allow multipathd to complete its DM table reload before `_device_for_lun` accesses the device. Without this, the device could appear ready in `/dev/disk/by-path` while multipathd still held it exclusively, causing intermittent EBUSY on the first I/O
+
+- **Fix force-logout retry incorrectly skipped during disk moves (GitHub issue #15)**: When `force_delete_on_inuse=1` is configured and a disk move has already allocated the destination LUN (making `active_luns >= 2`), the retry branch no longer resets `$need_force_logout` to 0. The retry now fires without a full target logout, relying on the prior SCSI teardown having released the specific LUN's kernel reference
+
+---
+
 ## Version 2.0.13 (March 31, 2026)
 
 ### Bug Fixes

--- a/wiki/Changelog.md
+++ b/wiki/Changelog.md
@@ -1,5 +1,13 @@
 # TrueNAS Plugin Changelog
 
+## Version 2.0.15 (April 3, 2026)
+
+### Bug Fixes
+
+- **Fix iSCSI extent deletion failing in cluster environments during disk moves (GitHub issue #24)**: Always pass `force=true` to `iscsi.targetextent.delete` and `iscsi.extent.delete` in `_free_image_iscsi`. Previously, the force flag was gated on local SCSI device teardown (`$scsi_teardown_done`), which stayed false when Proxmox had already deactivated the device before calling `free_image` (e.g., during disk moves). In cluster environments, other nodes maintain active iSCSI sessions to the shared target for their own VMs, causing TrueNAS to refuse deletion with "Associated target is in use". The force flag safely bypasses this check — TrueNAS logs a warning and proceeds, affecting only the specific LUN mapping being removed
+
+---
+
 ## Version 2.0.14 (April 2, 2026)
 
 ### Bug Fixes

--- a/wiki/README.md
+++ b/wiki/README.md
@@ -170,6 +170,6 @@ For issues not covered in documentation:
 
 ## Version Information
 
-**Version**: 2.0.14
-**Last Updated**: April 2, 2026
+**Version**: 2.0.15
+**Last Updated**: April 3, 2026
 **Compatibility**: Proxmox VE 8.x+, TrueNAS SCALE 25.10+

--- a/wiki/README.md
+++ b/wiki/README.md
@@ -170,6 +170,6 @@ For issues not covered in documentation:
 
 ## Version Information
 
-**Version**: 2.0.13
-**Last Updated**: March 31, 2026
+**Version**: 2.0.14
+**Last Updated**: April 2, 2026
 **Compatibility**: Proxmox VE 8.x+, TrueNAS SCALE 25.10+


### PR DESCRIPTION
Always force-delete iSCSI targetextent/extent in free_image to fix cluster disk move failures when other nodes have active sessions 

Fix for #24 