### PR TITLE
Fix VM migration size mismatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,6 @@ This project is provided as-is for use with Proxmox VE and TrueNAS SCALE.
 
 ---
 
-**Version**: 2.0.15
-**Last Updated**: April 3, 2026
+**Version**: 2.0.16
+**Last Updated**: April 7, 2026
 **Compatibility**: Proxmox VE 8.x+, TrueNAS SCALE 25.10+

--- a/TrueNASPlugin.pm
+++ b/TrueNASPlugin.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 
 # Plugin Version
-our $VERSION = '2.0.15';
+our $VERSION = '2.0.16';
 # Highest Proxmox storage API version this plugin is validated against.
 our $TESTED_APIVER = 13;
 use JSON::PP qw(encode_json decode_json);
@@ -4017,20 +4017,22 @@ sub alloc_image {
     # Level 2: Verbose - unit conversion details
     _log($scfg, 2, 'debug', "[TrueNAS] alloc_image: converting $size_kib KiB → $bytes bytes");
 
-    # Parse configured blocksize to bytes for alignment
-    my $bs_bytes = _parse_blocksize($scfg->{zvol_blocksize});
+    # Determine effective volblocksize: step down by halves until it evenly divides $bytes.
+    # Do NOT round $bytes up — that makes the zvol larger than requested and breaks QEMU
+    # drive-mirror size checks during VM migration (issue #25).
+    my $blocksize = $scfg->{zvol_blocksize};
+    my $bs_bytes  = _parse_blocksize($blocksize);
 
-    # Align to volblocksize if configured (mirrors volume_resize logic at line 1307-1311)
-    if ($bs_bytes && $bs_bytes > 0) {
-        my $original_bytes = $bytes;
-        my $rem = $bytes % $bs_bytes;
-        if ($rem) {
-            $bytes += ($bs_bytes - $rem);
-            _log($scfg, 1, 'info', "[TrueNAS] " . sprintf(
-                "alloc_image: size alignment: requested %d bytes → aligned %d bytes (volblocksize: %s)",
-                $original_bytes, $bytes, $scfg->{zvol_blocksize}
-            ));
+    if ($bs_bytes && $bs_bytes > 0 && ($bytes % $bs_bytes) != 0) {
+        my $orig_bs = $blocksize;
+        while ($bs_bytes > 512 && ($bytes % $bs_bytes) != 0) {
+            $bs_bytes = int($bs_bytes / 2);
         }
+        $blocksize = ($bs_bytes >= 1024) ? (int($bs_bytes / 1024) . 'K') : "$bs_bytes";
+        _log($scfg, 1, 'info', "[TrueNAS] " . sprintf(
+            "alloc_image: volblocksize stepped down: %s → %s to fit %d bytes exactly (avoids size mismatch on migration)",
+            $orig_bs, $blocksize, $bytes
+        ));
     }
 
     # Pre-flight checks: validate all prerequisites before expensive operations
@@ -4058,7 +4060,7 @@ sub alloc_image {
 
     # 1) Create the zvol (VOLUME) on TrueNAS with requested size
     # Note: $bytes already calculated above in space check (size in KiB * 1024)
-    my $blocksize = $scfg->{zvol_blocksize};
+    # Note: $blocksize was determined above (may be stepped-down from configured value)
 
     # Handle race condition: if dataset already exists (e.g., from concurrent delete still in progress),
     # retry with an incremented disk number. This can happen during rapid create/delete cycles where

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+truenas-proxmox-plugin (2.0.16+deb1) unstable; urgency=medium
+
+  * Fix VM migration size mismatch: step down volblocksize to fit requested bytes
+    exactly instead of rounding up, preventing QEMU drive-mirror abort (Issue #25)
+
+ -- TrueNAS Proxmox Plugin Maintainers <noreply@github.com>  Mon, 07 Apr 2026 00:00:00 +0000
+
 truenas-proxmox-plugin (2.0.15+deb1) unstable; urgency=medium
 
   * Always force-delete iSCSI targetextent/extent in free_image to fix cluster

--- a/wiki/Changelog.md
+++ b/wiki/Changelog.md
@@ -1,5 +1,13 @@
 # TrueNAS Plugin Changelog
 
+## Version 2.0.16 (April 7, 2026)
+
+### Bug Fixes
+
+- **Fix VM migration failing with "Source and target image have different sizes" (GitHub issue #25)**: `alloc_image` no longer rounds `$bytes` up to the next volblocksize boundary. Instead, the configured volblocksize is stepped down by halves until it evenly divides the requested size, ensuring the created zvol is exactly the size QEMU expects. Previously, a non-aligned size (e.g. 32 GiB with a 64K blocksize) caused the zvol to be created slightly larger than the source disk, causing QEMU's `drive-mirror` to abort with a size mismatch.
+
+---
+
 ## Version 2.0.15 (April 3, 2026)
 
 ### Bug Fixes

--- a/wiki/README.md
+++ b/wiki/README.md
@@ -170,6 +170,6 @@ For issues not covered in documentation:
 
 ## Version Information
 
-**Version**: 2.0.15
-**Last Updated**: April 3, 2026
+**Version**: 2.0.16
+**Last Updated**: April 7, 2026
 **Compatibility**: Proxmox VE 8.x+, TrueNAS SCALE 25.10+


### PR DESCRIPTION
Fix VM migration failing with "Source and target image have different sizes" (GitHub issue #25)**: `alloc_image` no longer rounds `$bytes` up to the next volblocksize boundary. Instead, the configured volblocksize is stepped down by halves until it evenly divides the requested size, ensuring the created zvol is exactly the size QEMU expects. Previously, a non-aligned size (e.g. 32 GiB with a 64K blocksize) caused the zvol to be created slightly larger than the source disk, causing QEMU's `drive-mirror` to abort with a size mismatch.