### PR TITLE
Fix extent ID cross-contamination and cache hardening (v2.0.27)

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,6 @@ This project is provided as-is for use with Proxmox VE and TrueNAS SCALE.
 
 ---
 
-**Version**: 2.0.20
-**Last Updated**: April 8, 2026
+**Version**: 2.0.23
+**Last Updated**: April 11, 2026
 **Compatibility**: Proxmox VE 8.x+, TrueNAS SCALE 25.10+

--- a/README.md
+++ b/README.md
@@ -324,6 +324,6 @@ This project is provided as-is for use with Proxmox VE and TrueNAS SCALE.
 
 ---
 
-**Version**: 2.0.15
-**Last Updated**: April 3, 2026
+**Version**: 2.0.16
+**Last Updated**: April 7, 2026
 **Compatibility**: Proxmox VE 8.x+, TrueNAS SCALE 25.10+

--- a/README.md
+++ b/README.md
@@ -324,6 +324,6 @@ This project is provided as-is for use with Proxmox VE and TrueNAS SCALE.
 
 ---
 
-**Version**: 2.0.26
-**Last Updated**: April 12, 2026
+**Version**: 2.0.27
+**Last Updated**: April 13, 2026
 **Compatibility**: Proxmox VE 8.x+, TrueNAS SCALE 25.10+

--- a/README.md
+++ b/README.md
@@ -324,6 +324,6 @@ This project is provided as-is for use with Proxmox VE and TrueNAS SCALE.
 
 ---
 
-**Version**: 2.0.23
-**Last Updated**: April 11, 2026
+**Version**: 2.0.24
+**Last Updated**: April 12, 2026
 **Compatibility**: Proxmox VE 8.x+, TrueNAS SCALE 25.10+

--- a/README.md
+++ b/README.md
@@ -324,6 +324,6 @@ This project is provided as-is for use with Proxmox VE and TrueNAS SCALE.
 
 ---
 
-**Version**: 2.0.18
+**Version**: 2.0.20
 **Last Updated**: April 8, 2026
 **Compatibility**: Proxmox VE 8.x+, TrueNAS SCALE 25.10+

--- a/README.md
+++ b/README.md
@@ -324,6 +324,6 @@ This project is provided as-is for use with Proxmox VE and TrueNAS SCALE.
 
 ---
 
-**Version**: 2.0.24
+**Version**: 2.0.26
 **Last Updated**: April 12, 2026
 **Compatibility**: Proxmox VE 8.x+, TrueNAS SCALE 25.10+

--- a/README.md
+++ b/README.md
@@ -324,6 +324,6 @@ This project is provided as-is for use with Proxmox VE and TrueNAS SCALE.
 
 ---
 
-**Version**: 2.0.17
-**Last Updated**: April 7, 2026
+**Version**: 2.0.18
+**Last Updated**: April 8, 2026
 **Compatibility**: Proxmox VE 8.x+, TrueNAS SCALE 25.10+

--- a/README.md
+++ b/README.md
@@ -324,6 +324,6 @@ This project is provided as-is for use with Proxmox VE and TrueNAS SCALE.
 
 ---
 
-**Version**: 2.0.16
+**Version**: 2.0.17
 **Last Updated**: April 7, 2026
 **Compatibility**: Proxmox VE 8.x+, TrueNAS SCALE 25.10+

--- a/TrueNASPlugin.pm
+++ b/TrueNASPlugin.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 
 # Plugin Version
-our $VERSION = '2.0.16';
+our $VERSION = '2.0.17';
 # Highest Proxmox storage API version this plugin is validated against.
 our $TESTED_APIVER = 13;
 use JSON::PP qw(encode_json decode_json);
@@ -5282,6 +5282,7 @@ sub _ensure_target_visible {
     # Step 5: Ensure extent is mapped to THIS target (not just any target)
     my $weight_mapped = 0;
     my $weight_extent_id;
+    my $stale_targetextent_id;  # mapping to wrong target left by cache-collision bug in older plugin versions
     eval {
         my $extents = _tn_extents($scfg);
         for my $ext (@$extents) {
@@ -5294,14 +5295,30 @@ sub _ensure_target_visible {
         if ($weight_extent_id) {
             my $targetextents = _tn_targetextents($scfg);
             for my $te (@$targetextents) {
-                # Check if extent is mapped to THIS specific target
-                if ($te->{extent} == $weight_extent_id && $te->{target} == $target_id) {
-                    $weight_mapped = 1;
-                    last;
+                if ($te->{extent} == $weight_extent_id) {
+                    if ($te->{target} == $target_id) {
+                        # Mapped to the correct target
+                        $weight_mapped = 1;
+                        last;
+                    } else {
+                        # Mapped to wrong target — stale from cache-collision bug in older plugin versions
+                        $stale_targetextent_id = $te->{id};
+                    }
                 }
             }
         }
     };
+
+    # Remove stale wrong-target mapping before creating the correct one
+    if ($stale_targetextent_id) {
+        _log($scfg, 1, 'info', "[TrueNAS] Pre-flight: removing stale weight extent mapping from wrong target (leftover from cache-collision bug)");
+        eval { _tn_targetextent_delete($scfg, $stale_targetextent_id); };
+        if ($@) {
+            _log($scfg, 0, 'warning', "[TrueNAS] Pre-flight: failed to remove stale weight mapping: $@");
+        } else {
+            _log($scfg, 1, 'info', "[TrueNAS] Pre-flight: stale weight mapping removed");
+        }
+    }
 
     if (!$weight_mapped && $weight_extent_id && $target_id) {
         _log($scfg, 1, 'info', "[TrueNAS] Pre-flight: mapping weight extent to target");

--- a/TrueNASPlugin.pm
+++ b/TrueNASPlugin.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 
 # Plugin Version
-our $VERSION = '2.0.18';
+our $VERSION = '2.0.20';
 # Highest Proxmox storage API version this plugin is validated against.
 our $TESTED_APIVER = 13;
 use JSON::PP qw(encode_json decode_json);
@@ -5206,8 +5206,13 @@ sub _ensure_target_visible {
     $target_suffix =~ s/-+/-/g;  # Collapse multiple dashes
     $target_suffix =~ s/^-|-$//g;  # Remove leading/trailing dashes
 
-    my $weight_name = "pve-weight-$target_suffix";
-    my $weight_zname = $scfg->{dataset} . '/' . $weight_name;
+    # Append an 8-char SHA1 prefix of the full IQN to guarantee uniqueness across targets
+    # whose sanitized suffixes could otherwise collide (e.g. "target.foo" and "target-foo"
+    # both sanitize to "target-foo"). sha1_hex is already imported via Digest::SHA.
+    my $iqn_hash8          = substr(sha1_hex($iqn), 0, 8);
+    my $weight_name        = "pve-weight-$target_suffix-$iqn_hash8";  # canonical (v2.0.20+)
+    my $weight_name_legacy = "pve-weight-$target_suffix";             # pre-v2.0.20 deployments
+    my $weight_zname       = $scfg->{dataset} . '/' . $weight_name;
 
     # Level 1: Log pre-flight check start
     _log($scfg, 1, 'info', "[TrueNAS] Pre-flight: checking target visibility for $iqn (weight: $weight_name)");
@@ -5272,41 +5277,60 @@ sub _ensure_target_visible {
         _log($scfg, 1, 'info', "[TrueNAS] Pre-flight: weight zvol already exists");
     }
 
-    # Step 4: Create extent for weight zvol if it doesn't exist
-    my $expected_disk = "zvol/$weight_zname";
-    my $weight_extent_exists = 0;
+    # Step 4: Create extent for weight zvol if it doesn't exist.
+    # The weight extent is scoped to the iSCSI target (IQN), not the storage dataset.
+    # Multiple storages sharing the same target share the same weight extent, so we
+    # match by name only — the disk path may differ if another storage created it first.
+    # Try the canonical (new) name first, then fall back to the legacy name for clusters
+    # that already have a weight extent created by an older plugin version.
+    my $found_weight_name;  # actual name of the weight extent on TrueNAS (may be legacy)
     eval {
         my $extents = _tn_extents($scfg);
         for my $ext (@$extents) {
-            if (($ext->{name} // '') eq $weight_name && ($ext->{disk} // '') eq $expected_disk) {
-                $weight_extent_exists = 1;
+            my $ext_name = $ext->{name} // '';
+            if ($ext_name eq $weight_name) {
+                $found_weight_name = $weight_name;
+                last;
+            } elsif ($ext_name eq $weight_name_legacy) {
+                $found_weight_name = $weight_name_legacy;
+                _log($scfg, 1, 'info', "[TrueNAS] Pre-flight: using legacy weight extent '$weight_name_legacy' (pre-v2.0.20 name format; will continue working)");
                 last;
             }
         }
     };
 
-    if (!$weight_extent_exists) {
+    if (!$found_weight_name) {
         _log($scfg, 1, 'info', "[TrueNAS] Pre-flight: creating extent for weight zvol");
         eval {
             _tn_extent_create($scfg, $weight_name, $weight_zname);
         };
         if ($@) {
-            _log($scfg, 0, 'err', "[TrueNAS] Pre-flight: failed to create weight extent: $@");
-            die "Failed to create weight extent: $@\n";
+            if ($@ =~ /Extent name must be unique/i) {
+                # Another storage or concurrent process already created the weight extent
+                _log($scfg, 1, 'info', "[TrueNAS] Pre-flight: weight extent already exists (created concurrently or by another storage)");
+                _clear_cache($scfg->{api_host} || $scfg->{storeid} || 'unknown');
+                $found_weight_name = $weight_name;  # it exists now — step 5 will fetch it fresh
+            } else {
+                _log($scfg, 0, 'err', "[TrueNAS] Pre-flight: failed to create weight extent: $@");
+                die "Failed to create weight extent: $@\n";
+            }
+        } else {
+            _log($scfg, 1, 'info', "[TrueNAS] Pre-flight: weight extent created");
+            $found_weight_name = $weight_name;
         }
-        _log($scfg, 1, 'info', "[TrueNAS] Pre-flight: weight extent created");
     } else {
         _log($scfg, 1, 'info', "[TrueNAS] Pre-flight: weight extent already exists");
     }
 
-    # Step 5: Ensure extent is mapped to THIS target (not just any target)
+    # Step 5: Ensure extent is mapped to THIS target (not just any target).
+    # Use $found_weight_name (may be legacy) so that lookups stay consistent with step 4.
     my $weight_mapped = 0;
     my $weight_extent_id;
     my $stale_targetextent_id;  # mapping to wrong target left by cache-collision bug in older plugin versions
     eval {
         my $extents = _tn_extents($scfg);
         for my $ext (@$extents) {
-            if (($ext->{name} // '') eq $weight_name && ($ext->{disk} // '') eq $expected_disk) {
+            if (($ext->{name} // '') eq ($found_weight_name // '')) {
                 $weight_extent_id = $ext->{id};
                 last;
             }

--- a/TrueNASPlugin.pm
+++ b/TrueNASPlugin.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 
 # Plugin Version
-our $VERSION = '2.0.24';
+our $VERSION = '2.0.26';
 # Highest Proxmox storage API version this plugin is validated against.
 our $TESTED_APIVER = 13;
 use JSON::PP qw(encode_json decode_json);
@@ -83,6 +83,12 @@ sub _cache_key {
     return "${storage_id}:${method}";
 }
 
+# Returns the cache host key for a storage config (api_host preferred, storeid fallback)
+sub _cache_host_key {
+    my ($scfg) = @_;
+    return $scfg->{api_host} || $scfg->{storeid} || 'unknown';
+}
+
 sub _get_cached {
     my ($storage_id, $method) = @_;
     my $key = _cache_key($storage_id, $method);
@@ -117,6 +123,12 @@ sub _clear_cache {
     }
     # Also clear the portal sync cache (not scoped by api_host, clear entirely)
     %_portal_sync_last_ok = ();
+}
+
+# Invalidate a specific cache entry without clearing the entire host's cache
+sub _invalidate_cache_key {
+    my ($host_key, $method) = @_;
+    delete $API_CACHE{_cache_key($host_key, $method)};
 }
 
 # ======== Helper functions ========
@@ -1497,7 +1509,7 @@ sub _tn_get_target($scfg) {
     return _api_call($scfg, 'iscsi.target.query', []);
 }
 sub _tn_targetextents($scfg) {
-    my $storage_id = $scfg->{api_host} || $scfg->{storeid} || 'unknown';
+    my $storage_id = _cache_host_key($scfg);
 
     # Try cache first (but with shorter TTL since mappings change more frequently)
     my $cached = _get_cached($storage_id, 'targetextents');
@@ -1510,7 +1522,7 @@ sub _tn_targetextents($scfg) {
     return _set_cache($storage_id, 'targetextents', $res);
 }
 sub _tn_extents($scfg) {
-    my $storage_id = $scfg->{api_host} || $scfg->{storeid} || 'unknown';
+    my $storage_id = _cache_host_key($scfg);
 
     # Try cache first
     my $cached = _get_cached($storage_id, 'extents');
@@ -2092,13 +2104,13 @@ sub _tn_extent_create($scfg, $zname, $full, $extent_name=undef) {
     };
     my $result = _api_call_write($scfg, 'iscsi.extent.create', [ $payload ]);
     # Invalidate cache since extents list has changed
-    _clear_cache($scfg->{api_host} || $scfg->{storeid} || 'unknown') if $result;
+    _clear_cache(_cache_host_key($scfg)) if $result;
     return $result;
 }
 sub _tn_extent_delete($scfg, $extent_id) {
     my $result = _api_call_write($scfg, 'iscsi.extent.delete', [ $extent_id ]);
     # Invalidate cache since extents list has changed
-    _clear_cache($scfg->{api_host} || $scfg->{storeid} || 'unknown') if $result;
+    _clear_cache(_cache_host_key($scfg)) if $result;
     return $result;
 }
 sub _tn_targetextent_create($scfg, $target_id, $extent_id, $lun) {
@@ -2124,7 +2136,7 @@ sub _tn_targetextent_create($scfg, $target_id, $extent_id, $lun) {
         if ($err =~ /Extent is already in use/i) {
             # Cache may be stale — force-refresh and check if already correctly mapped
             # (can happen when another cluster node created the mapping after our cache was populated)
-            my $host_key = $scfg->{api_host} || $scfg->{storeid} || 'unknown';
+            my $host_key = _cache_host_key($scfg);
             _clear_cache($host_key);
             my $fresh_maps = _tn_targetextents($scfg) // [];
             my ($found) = grep {
@@ -2139,13 +2151,13 @@ sub _tn_targetextent_create($scfg, $target_id, $extent_id, $lun) {
     }
 
     # Invalidate cache since targetextents list has changed
-    _clear_cache($scfg->{api_host} || $scfg->{storeid} || 'unknown') if $result;
+    _clear_cache(_cache_host_key($scfg)) if $result;
     return $result;
 }
 sub _tn_targetextent_delete($scfg, $tx_id) {
     my $result = _api_call_write($scfg, 'iscsi.targetextent.delete', [ $tx_id ]);
     # Invalidate cache since targetextents list has changed
-    _clear_cache($scfg->{api_host} || $scfg->{storeid} || 'unknown') if $result;
+    _clear_cache(_cache_host_key($scfg)) if $result;
     return $result;
 }
 sub _current_lun_for_zname($scfg, $zname) {
@@ -4195,7 +4207,7 @@ sub _alloc_image_iscsi {
     my $extent_id;
     {
         my $ext = eval {
-            _api_call(
+            _api_call_write(
                 $scfg,
                 'iscsi.extent.create',
                 [ $extent_payload ],
@@ -4209,7 +4221,7 @@ sub _alloc_image_iscsi {
         # normalize id from WebSocket result (hashref)
         $extent_id = ref($ext) eq 'HASH' ? $ext->{id} : $ext;
         # Invalidate cache so subsequent targetextents lookup sees current state
-        _clear_cache($scfg->{api_host} || $scfg->{storeid} || 'unknown');
+        _clear_cache(_cache_host_key($scfg));
     }
     if (!defined $extent_id) {
         eval { _tn_dataset_delete($scfg, $full_ds) };
@@ -4251,7 +4263,7 @@ sub _alloc_image_iscsi {
         $lun = ref($tx) eq 'HASH' ? $tx->{lunid} : undef;
 
         # Invalidate cache after creating new mapping
-        _clear_cache($scfg->{api_host} || $scfg->{storeid} || 'unknown');
+        _clear_cache(_cache_host_key($scfg));
 
         # Fallback: re-fetch if create response didn't include lunid
         if (!defined $lun) {
@@ -4584,7 +4596,7 @@ sub _free_image_iscsi {
     if ($need_force_logout) {
         # Invalidate cache to get fresh targetextent data — a destination LUN may have been
         # created since the cache was last populated (e.g., during a disk move operation)
-        _clear_cache($scfg->{api_host} || $scfg->{storeid} || 'unknown');
+        _clear_cache(_cache_host_key($scfg));
         # Check how many LUNs are currently mapped to this target
         my $active_luns = 0;
         eval {
@@ -5285,9 +5297,23 @@ sub _ensure_target_visible {
     # This prevents issues where weight gets deleted and target becomes undiscoverable
     _log($scfg, 1, 'info', "[TrueNAS] Pre-flight: ensuring weight volume exists for target reliability");
     my $weight_exists = 0;
+    my $weight_zname_legacy = $scfg->{dataset} . '/' . $weight_name_legacy;
+    my $using_legacy_zvol = 0;  # true if we found the legacy zvol (affects step 4 disk-path check)
     eval {
         my $ds = _tn_dataset_get($scfg, $weight_zname);
-        $weight_exists = 1 if $ds;
+        if ($ds) {
+            $weight_exists = 1;
+        } else {
+            # Also check for legacy-named zvol (pre-v2.0.20 clusters upgrading in-place)
+            # If found, continue using it — no need to create a duplicate hash-named zvol.
+            # The legacy extent will continue to point to this zvol and work correctly.
+            my $ds_legacy = _tn_dataset_get($scfg, $weight_zname_legacy);
+            if ($ds_legacy) {
+                $weight_exists = 1;
+                $using_legacy_zvol = 1;
+                _log($scfg, 1, 'info', "[TrueNAS] Pre-flight: found legacy weight zvol '$weight_zname_legacy' (pre-v2.0.20); continuing to use it");
+            }
+        }
     };
 
     my $weight_zvol_just_created = 0;  # tracks whether we created the zvol in this run (for L1 disk-path check in step 4)
@@ -5359,7 +5385,7 @@ sub _ensure_target_visible {
             if ($@ =~ /Extent name must be unique/i) {
                 # Another storage or concurrent process already created the weight extent
                 _log($scfg, 1, 'info', "[TrueNAS] Pre-flight: weight extent already exists (created concurrently or by another storage)");
-                _clear_cache($scfg->{api_host} || $scfg->{storeid} || 'unknown');
+                _clear_cache(_cache_host_key($scfg));
                 $found_weight_name = $weight_name;  # it exists now — step 5 will fetch it fresh
             } else {
                 _log($scfg, 0, 'err', "[TrueNAS] Pre-flight: failed to create weight extent: $@");
@@ -5378,10 +5404,8 @@ sub _ensure_target_visible {
     # but the extent was subsequently deleted on TrueNAS, using the cached ID for
     # iscsi.targetextent.create would trigger a FOREIGN KEY constraint failure.
     # Always resolve the extent ID against live TrueNAS data before mapping.
-    {
-        my $_hk = $scfg->{api_host} || $scfg->{storeid} || 'unknown';
-        delete $API_CACHE{_cache_key($_hk, 'extents')};
-    }
+    # Force-invalidate extents cache so step 5 ID lookup uses live TrueNAS data
+    _invalidate_cache_key(_cache_host_key($scfg), 'extents');
     # Use $found_weight_name (may be legacy) so that lookups stay consistent with step 4.
     my $weight_mapped = 0;
     my $weight_extent_id;
@@ -5414,7 +5438,7 @@ sub _ensure_target_visible {
     };
 
     # Remove stale wrong-target mapping before creating the correct one
-    my $stale_delete_ok = 1;
+    my $stale_cleared = 1;
     if ($stale_targetextent_id) {
         _log($scfg, 1, 'info', "[TrueNAS] Pre-flight: removing stale weight extent mapping from wrong target (leftover from cache-collision bug)");
         eval { _tn_targetextent_delete($scfg, $stale_targetextent_id); };
@@ -5423,17 +5447,17 @@ sub _ensure_target_visible {
                 # Mapping was already deleted (concurrent cleanup from another node, or stale cache)
                 # — desired state achieved; clear cache and proceed with correct mapping create
                 _log($scfg, 1, 'info', "[TrueNAS] Pre-flight: stale mapping already gone (concurrent cleanup), continuing");
-                _clear_cache($scfg->{api_host} || $scfg->{storeid} || 'unknown');
+                _clear_cache(_cache_host_key($scfg));
             } else {
                 _log($scfg, 0, 'warning', "[TrueNAS] Pre-flight: failed to remove stale weight mapping: $@");
-                $stale_delete_ok = 0;  # extent still locked to wrong target — skip create attempt
+                $stale_cleared = 0;  # extent still locked to wrong target — skip create attempt
             }
         } else {
             _log($scfg, 1, 'info', "[TrueNAS] Pre-flight: stale weight mapping removed");
         }
     }
 
-    if (!$weight_mapped && $stale_delete_ok && $weight_extent_id && $target_id) {
+    if (!$weight_mapped && $stale_cleared && $weight_extent_id && $target_id) {
         _log($scfg, 1, 'info', "[TrueNAS] Pre-flight: mapping weight extent to target");
         eval {
             _tn_targetextent_create($scfg, $target_id, $weight_extent_id, 0);
@@ -5446,7 +5470,7 @@ sub _ensure_target_visible {
                     if ($@ =~ /FOREIGN KEY constraint failed|IntegrityError/i) {
                         # Extent ID exists in TrueNAS query but not in SQLite — configfs/DB desync.
                         # Delete the stale extent to force TrueNAS to resync; next cycle will recreate.
-                        my $_hk = $scfg->{api_host} || $scfg->{storeid} || 'unknown';
+                        my $_hk = _cache_host_key($scfg);
                         _log($scfg, 1, 'info', "[TrueNAS] Pre-flight: weight extent ID $weight_extent_id is stale (FK constraint failed), deleting to force resync");
                         eval { _tn_extent_delete($scfg, $weight_extent_id) };
                         if ($@) {
@@ -5462,7 +5486,7 @@ sub _ensure_target_visible {
             } elsif ($@ =~ /FOREIGN KEY constraint failed|IntegrityError/i) {
                 # Extent ID exists in TrueNAS query but not in SQLite — configfs/DB desync.
                 # Delete the stale extent to force TrueNAS to resync; next cycle will recreate.
-                my $_hk = $scfg->{api_host} || $scfg->{storeid} || 'unknown';
+                my $_hk = _cache_host_key($scfg);
                 _log($scfg, 1, 'info', "[TrueNAS] Pre-flight: weight extent ID $weight_extent_id is stale (FK constraint failed), deleting to force resync");
                 eval { _tn_extent_delete($scfg, $weight_extent_id) };
                 if ($@) {
@@ -5649,7 +5673,7 @@ sub _clone_image_iscsi {
             if ($@ =~ /dataset already exists/i && !$name) {
                 # Race condition: name was taken between find and clone; pick a new one
                 _log($scfg, 1, 'warn', "[TrueNAS] _clone_image_iscsi: $target_full already exists (attempt $clone_attempt/$max_clone_retries), retrying with new name");
-                _clear_cache($scfg->{api_host} || $scfg->{storeid} || 'unknown');
+                _clear_cache(_cache_host_key($scfg));
                 $target_zname = _find_free_disk_name($scfg, $vmid);
                 $target_full  = $scfg->{dataset} . '/' . $target_zname;
                 next;
@@ -5694,7 +5718,7 @@ sub _clone_image_iscsi {
         };
 
         my $ext = eval {
-            _api_call(
+            _api_call_write(
                 $scfg,
                 'iscsi.extent.create',
                 [ $extent_payload ],
@@ -5707,7 +5731,7 @@ sub _clone_image_iscsi {
         }
         $extent_id = ref($ext) eq 'HASH' ? $ext->{id} : $ext;
         # Invalidate cache so the subsequent targetextents lookup sees current state
-        _clear_cache($scfg->{api_host} || $scfg->{storeid} || 'unknown');
+        _clear_cache(_cache_host_key($scfg));
     }
 
     die "failed to create extent for clone $target_zname\n" if !defined $extent_id;
@@ -5730,7 +5754,7 @@ sub _clone_image_iscsi {
         $lun = ref($tx) eq 'HASH' ? $tx->{lunid} : undef;
 
         # Invalidate cache after creating new mapping
-        _clear_cache($scfg->{api_host} || $scfg->{storeid} || 'unknown');
+        _clear_cache(_cache_host_key($scfg));
 
         # Fallback: re-fetch if create response didn't include lunid
         if (!defined $lun) {
@@ -5790,7 +5814,7 @@ sub _clone_image_nvme {
             last unless $@;
             if ($@ =~ /dataset already exists/i && !$name) {
                 _log($scfg, 1, 'warn', "[TrueNAS] _clone_image_nvme: $target_full already exists (attempt $clone_attempt/$max_clone_retries), retrying with new name");
-                _clear_cache($scfg->{api_host} || $scfg->{storeid} || 'unknown');
+                _clear_cache(_cache_host_key($scfg));
                 $target_zname = _find_free_disk_name($scfg, $vmid);
                 $target_full  = $scfg->{dataset} . '/' . $target_zname;
                 next;

--- a/TrueNASPlugin.pm
+++ b/TrueNASPlugin.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 
 # Plugin Version
-our $VERSION = '2.0.26';
+our $VERSION = '2.0.27';
 # Highest Proxmox storage API version this plugin is validated against.
 our $TESTED_APIVER = 13;
 use JSON::PP qw(encode_json decode_json);
@@ -121,8 +121,12 @@ sub _clear_cache {
         %API_CACHE = ();
         %_preflight_last_ok = ();
     }
-    # Also clear the portal sync cache (not scoped by api_host, clear entirely)
-    %_portal_sync_last_ok = ();
+    # Keep portal sync cache aligned with the same host scoping
+    if ($storage_id) {
+        delete $_portal_sync_last_ok{$storage_id};
+    } else {
+        %_portal_sync_last_ok = ();
+    }
 }
 
 # Invalidate a specific cache entry without clearing the entire host's cache
@@ -2160,6 +2164,17 @@ sub _tn_targetextent_delete($scfg, $tx_id) {
     _clear_cache(_cache_host_key($scfg)) if $result;
     return $result;
 }
+sub _handle_fk_stale_extent {
+    my ($scfg, $weight_extent_id) = @_;
+
+    _log($scfg, 1, 'info', "[TrueNAS] Pre-flight: weight extent ID $weight_extent_id is stale (FK constraint failed), deleting to force resync");
+    eval { _tn_extent_delete($scfg, $weight_extent_id) };
+    if ($@) {
+        _log($scfg, 1, 'info', "[TrueNAS] Pre-flight: stale extent delete failed (may already be gone): $@");
+    }
+    _clear_cache(_cache_host_key($scfg));
+}
+
 sub _current_lun_for_zname($scfg, $zname) {
     my $extents = _tn_extents($scfg) // [];
     my $zvol_path = "zvol/$scfg->{dataset}/$zname";
@@ -2179,7 +2194,7 @@ sub _current_lun_for_zname($scfg, $zname) {
 # Results are cached for 30 seconds to avoid redundant checks during multi-disk creation.
 sub _preflight_check_alloc {
     my ($scfg, $size_bytes) = @_;
-    my $api_host_key = $scfg->{api_host} // 'unknown';
+    my $api_host_key = _cache_host_key($scfg);
 
     # Skip redundant preflight checks when allocating multiple disks rapidly
     if (time() - ($_preflight_last_ok{$api_host_key} // 0) < 30) {
@@ -2330,7 +2345,7 @@ sub _preflight_check_alloc {
 sub _resolve_target_id {
     my ($scfg) = @_;
     my $want = $scfg->{target_iqn} // die "target_iqn not set in storage.cfg\n";
-    my $api_host = $scfg->{api_host} // '';
+    my $api_host = _cache_host_key($scfg);
 
     # Use the TTL-based %API_CACHE (60s) so stale IDs are automatically refreshed
     # and _clear_cache() always invalidates this alongside other cached data.
@@ -3718,7 +3733,7 @@ sub _nvme_device_for_uuid {
 sub _nvme_sync_portals {
     my ($scfg, $subsys_id) = @_;
 
-    my $sid = $scfg->{api_host} // 'unknown';
+    my $sid = _cache_host_key($scfg);
     if (time() - ($_portal_sync_last_ok{$sid} // 0) < $CACHE_TTL) {
         _log($scfg, 2, 'debug', "[TrueNAS] nvme_sync_portals: skipping (recently synced "
             . (time() - $_portal_sync_last_ok{$sid}) . "s ago)");
@@ -4063,21 +4078,24 @@ sub alloc_image {
     # Level 2: Verbose - unit conversion details
     _log($scfg, 2, 'debug', "[TrueNAS] alloc_image: converting $size_kib KiB → $bytes bytes");
 
-    # Parse configured blocksize to bytes for alignment
-    my $bs_bytes = _parse_blocksize($scfg->{zvol_blocksize});
+    # Determine effective volblocksize: step down by halves until it evenly divides $bytes.
+    # Do NOT round $bytes up — that makes the zvol larger than requested and breaks QEMU
+    # drive-mirror size checks during VM migration (issue #25).
+    my $blocksize = $scfg->{zvol_blocksize};
+    my $bs_bytes  = _parse_blocksize($blocksize);
 
-    # Align to volblocksize if configured (mirrors volume_resize logic at line 1307-1311)
-    if ($bs_bytes && $bs_bytes > 0) {
-        my $original_bytes = $bytes;
-        my $rem = $bytes % $bs_bytes;
-        if ($rem) {
-            $bytes += ($bs_bytes - $rem);
-            _log($scfg, 1, 'info', "[TrueNAS] " . sprintf(
-                "alloc_image: size alignment: requested %d bytes → aligned %d bytes (volblocksize: %s)",
-                $original_bytes, $bytes, $scfg->{zvol_blocksize}
-            ));
+    if ($bs_bytes && $bs_bytes > 0 && ($bytes % $bs_bytes) != 0) {
+        my $orig_bs = $blocksize;
+        while ($bs_bytes > 512 && ($bytes % $bs_bytes) != 0) {
+            $bs_bytes = int($bs_bytes / 2);
         }
+        $blocksize = ($bs_bytes >= 1024) ? (int($bs_bytes / 1024) . 'K') : "$bs_bytes";
+        _log($scfg, 1, 'info', "[TrueNAS] " . sprintf(
+            "alloc_image: volblocksize stepped down: %s → %s to fit %d bytes exactly (avoids size mismatch on migration)",
+            $orig_bs, $blocksize, $bytes
+        ));
     }
+
 
     # Pre-flight checks: validate all prerequisites before expensive operations
     _log($scfg, 1, 'info', "[TrueNAS] alloc_image: running pre-flight checks for $bytes bytes");
@@ -4104,7 +4122,7 @@ sub alloc_image {
 
     # 1) Create the zvol (VOLUME) on TrueNAS with requested size
     # Note: $bytes already calculated above in space check (size in KiB * 1024)
-    my $blocksize = $scfg->{zvol_blocksize};
+    # Note: $blocksize was determined above (may be stepped-down from configured value)
 
     # Handle race condition: if dataset already exists (e.g., from concurrent delete still in progress),
     # retry with an incremented disk number. This can happen during rapid create/delete cycles where
@@ -5298,7 +5316,6 @@ sub _ensure_target_visible {
     _log($scfg, 1, 'info', "[TrueNAS] Pre-flight: ensuring weight volume exists for target reliability");
     my $weight_exists = 0;
     my $weight_zname_legacy = $scfg->{dataset} . '/' . $weight_name_legacy;
-    my $using_legacy_zvol = 0;  # true if we found the legacy zvol (affects step 4 disk-path check)
     eval {
         my $ds = _tn_dataset_get($scfg, $weight_zname);
         if ($ds) {
@@ -5310,7 +5327,6 @@ sub _ensure_target_visible {
             my $ds_legacy = _tn_dataset_get($scfg, $weight_zname_legacy);
             if ($ds_legacy) {
                 $weight_exists = 1;
-                $using_legacy_zvol = 1;
                 _log($scfg, 1, 'info', "[TrueNAS] Pre-flight: found legacy weight zvol '$weight_zname_legacy' (pre-v2.0.20); continuing to use it");
             }
         }
@@ -5470,13 +5486,7 @@ sub _ensure_target_visible {
                     if ($@ =~ /FOREIGN KEY constraint failed|IntegrityError/i) {
                         # Extent ID exists in TrueNAS query but not in SQLite — configfs/DB desync.
                         # Delete the stale extent to force TrueNAS to resync; next cycle will recreate.
-                        my $_hk = _cache_host_key($scfg);
-                        _log($scfg, 1, 'info', "[TrueNAS] Pre-flight: weight extent ID $weight_extent_id is stale (FK constraint failed), deleting to force resync");
-                        eval { _tn_extent_delete($scfg, $weight_extent_id) };
-                        if ($@) {
-                            _log($scfg, 1, 'info', "[TrueNAS] Pre-flight: stale extent delete failed (may already be gone): $@");
-                        }
-                        _clear_cache($_hk);
+                        _handle_fk_stale_extent($scfg, $weight_extent_id);
                     } else {
                         _log($scfg, 0, 'warning', "[TrueNAS] Pre-flight: failed to map weight extent with auto LUN: $@");
                     }
@@ -5486,13 +5496,7 @@ sub _ensure_target_visible {
             } elsif ($@ =~ /FOREIGN KEY constraint failed|IntegrityError/i) {
                 # Extent ID exists in TrueNAS query but not in SQLite — configfs/DB desync.
                 # Delete the stale extent to force TrueNAS to resync; next cycle will recreate.
-                my $_hk = _cache_host_key($scfg);
-                _log($scfg, 1, 'info', "[TrueNAS] Pre-flight: weight extent ID $weight_extent_id is stale (FK constraint failed), deleting to force resync");
-                eval { _tn_extent_delete($scfg, $weight_extent_id) };
-                if ($@) {
-                    _log($scfg, 1, 'info', "[TrueNAS] Pre-flight: stale extent delete failed (may already be gone): $@");
-                }
-                _clear_cache($_hk);
+                _handle_fk_stale_extent($scfg, $weight_extent_id);
             } else {
                 _log($scfg, 0, 'warning', "[TrueNAS] Pre-flight: failed to map weight extent: $@");
             }
@@ -5680,7 +5684,7 @@ sub _clone_image_iscsi {
             }
             die $@;
         }
-        die "Failed to create clone after $max_clone_retries attempts\n" if $clone_attempt >= $max_clone_retries && !defined $clone_result;
+        die "Failed to create clone after $max_clone_retries attempts\n" if !defined $clone_result;
     }
 
     # Wait for clone job to complete if it returned a job ID
@@ -5821,7 +5825,7 @@ sub _clone_image_nvme {
             }
             die $@;
         }
-        die "Failed to create clone after $max_clone_retries attempts\n" if $clone_attempt >= $max_clone_retries && !defined $clone_result;
+        die "Failed to create clone after $max_clone_retries attempts\n" if !defined $clone_result;
     }
 
     # Wait for clone job to complete if it returned a job ID

--- a/TrueNASPlugin.pm
+++ b/TrueNASPlugin.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 
 # Plugin Version
-our $VERSION = '2.0.15';
+our $VERSION = '2.0.16';
 # Highest Proxmox storage API version this plugin is validated against.
 our $TESTED_APIVER = 13;
 use JSON::PP qw(encode_json decode_json);
@@ -45,8 +45,8 @@ my $CACHE_TTL = 60; # 60 seconds
 # Per-process cache for _resolve_target_id results (avoids redundant API calls)
 my %_target_id_cache;
 
-# Per-process cache for preflight check results (time-based, 30s validity)
-my $_preflight_last_ok = 0;
+# Per-host cache for preflight check results (time-based, 30s validity)
+my %_preflight_last_ok;
 
 # Per-storage cache for NVMe portal sync (avoids redundant port_subsys.query on every alloc)
 my %_portal_sync_last_ok;
@@ -110,14 +110,17 @@ sub _set_cache {
 sub _clear_cache {
     my ($storage_id) = @_;
     if ($storage_id) {
-        # Clear cache for specific storage
+        # Clear cache for specific storage (storage_id is api_host)
         delete $API_CACHE{$_} for grep { /^\Q$storage_id\E:/ } keys %API_CACHE;
+        delete $_target_id_cache{$_} for grep { /^\Q$storage_id\E:/ } keys %_target_id_cache;
+        delete $_preflight_last_ok{$storage_id};
     } else {
         # Clear all cache
         %API_CACHE = ();
+        %_target_id_cache = ();
+        %_preflight_last_ok = ();
     }
-    # Also clear the target ID and portal sync caches
-    %_target_id_cache = ();
+    # Also clear the portal sync cache (not scoped by api_host, clear entirely)
     %_portal_sync_last_ok = ();
 }
 
@@ -1494,7 +1497,7 @@ sub _tn_get_target($scfg) {
     return _api_call($scfg, 'iscsi.target.query', []);
 }
 sub _tn_targetextents($scfg) {
-    my $storage_id = $scfg->{storeid} || 'unknown';
+    my $storage_id = $scfg->{api_host} || $scfg->{storeid} || 'unknown';
 
     # Try cache first (but with shorter TTL since mappings change more frequently)
     my $cached = _get_cached($storage_id, 'targetextents');
@@ -1507,7 +1510,7 @@ sub _tn_targetextents($scfg) {
     return _set_cache($storage_id, 'targetextents', $res);
 }
 sub _tn_extents($scfg) {
-    my $storage_id = $scfg->{storeid} || 'unknown';
+    my $storage_id = $scfg->{api_host} || $scfg->{storeid} || 'unknown';
 
     # Try cache first
     my $cached = _get_cached($storage_id, 'extents');
@@ -2081,13 +2084,13 @@ sub _tn_extent_create($scfg, $zname, $full, $extent_name=undef) {
     };
     my $result = _api_call_write($scfg, 'iscsi.extent.create', [ $payload ]);
     # Invalidate cache since extents list has changed
-    _clear_cache($scfg->{storeid}) if $result;
+    _clear_cache($scfg->{api_host} || $scfg->{storeid} || 'unknown') if $result;
     return $result;
 }
 sub _tn_extent_delete($scfg, $extent_id) {
     my $result = _api_call_write($scfg, 'iscsi.extent.delete', [ $extent_id ]);
     # Invalidate cache since extents list has changed
-    _clear_cache($scfg->{storeid}) if $result;
+    _clear_cache($scfg->{api_host} || $scfg->{storeid} || 'unknown') if $result;
     return $result;
 }
 sub _tn_targetextent_create($scfg, $target_id, $extent_id, $lun) {
@@ -2108,13 +2111,13 @@ sub _tn_targetextent_create($scfg, $target_id, $extent_id, $lun) {
     $payload->{lunid} = $lun if defined $lun;
     my $result = _api_call_write($scfg, 'iscsi.targetextent.create', [ $payload ]);
     # Invalidate cache since targetextents list has changed
-    _clear_cache($scfg->{storeid}) if $result;
+    _clear_cache($scfg->{api_host} || $scfg->{storeid} || 'unknown') if $result;
     return $result;
 }
 sub _tn_targetextent_delete($scfg, $tx_id) {
     my $result = _api_call_write($scfg, 'iscsi.targetextent.delete', [ $tx_id ]);
     # Invalidate cache since targetextents list has changed
-    _clear_cache($scfg->{storeid}) if $result;
+    _clear_cache($scfg->{api_host} || $scfg->{storeid} || 'unknown') if $result;
     return $result;
 }
 sub _current_lun_for_zname($scfg, $zname) {
@@ -2136,10 +2139,11 @@ sub _current_lun_for_zname($scfg, $zname) {
 # Results are cached for 30 seconds to avoid redundant checks during multi-disk creation.
 sub _preflight_check_alloc {
     my ($scfg, $size_bytes) = @_;
+    my $api_host_key = $scfg->{api_host} // 'unknown';
 
     # Skip redundant preflight checks when allocating multiple disks rapidly
-    if (time() - $_preflight_last_ok < 30) {
-        _log($scfg, 2, 'debug', "[TrueNAS] _preflight_check_alloc: skipping (recently validated " . (time() - $_preflight_last_ok) . "s ago)");
+    if (time() - ($_preflight_last_ok{$api_host_key} // 0) < 30) {
+        _log($scfg, 2, 'debug', "[TrueNAS] _preflight_check_alloc: skipping (recently validated " . (time() - $_preflight_last_ok{$api_host_key}) . "s ago)");
         return [];
     }
 
@@ -2276,7 +2280,7 @@ sub _preflight_check_alloc {
     }
 
     # Cache successful result for 30s to speed up multi-disk creation
-    $_preflight_last_ok = time() if !@errors;
+    $_preflight_last_ok{$api_host_key} = time() if !@errors;
 
     return \@errors;
 }
@@ -2286,11 +2290,13 @@ sub _preflight_check_alloc {
 sub _resolve_target_id {
     my ($scfg) = @_;
     my $want = $scfg->{target_iqn} // die "target_iqn not set in storage.cfg\n";
+    my $api_host = $scfg->{api_host} // '';
+    my $cache_key = "$api_host:$want";
 
     # Return cached result if available
-    if (exists $_target_id_cache{$want}) {
-        _log($scfg, 2, 'debug', "[TrueNAS] _resolve_target_id: using cached target_id=$_target_id_cache{$want} for $want");
-        return $_target_id_cache{$want};
+    if (exists $_target_id_cache{$cache_key}) {
+        _log($scfg, 2, 'debug', "[TrueNAS] _resolve_target_id: using cached target_id=$_target_id_cache{$cache_key} for $want");
+        return $_target_id_cache{$cache_key};
     }
 
     # 1) Get targets; if empty, surface a clear diagnostic
@@ -2360,7 +2366,7 @@ sub _resolve_target_id {
             $want
         );
     }
-    $_target_id_cache{$want} = $found->{id};
+    $_target_id_cache{$cache_key} = $found->{id};
     return $found->{id};
 }
 
@@ -3672,7 +3678,7 @@ sub _nvme_device_for_uuid {
 sub _nvme_sync_portals {
     my ($scfg, $subsys_id) = @_;
 
-    my $sid = $scfg->{storeid} // 'unknown';
+    my $sid = $scfg->{api_host} // 'unknown';
     if (time() - ($_portal_sync_last_ok{$sid} // 0) < $CACHE_TTL) {
         _log($scfg, 2, 'debug', "[TrueNAS] nvme_sync_portals: skipping (recently synced "
             . (time() - $_portal_sync_last_ok{$sid}) . "s ago)");
@@ -4212,7 +4218,7 @@ sub _alloc_image_iscsi {
         $lun = ref($tx) eq 'HASH' ? $tx->{lunid} : undef;
 
         # Invalidate cache after creating new mapping
-        _clear_cache($scfg->{storeid} || 'unknown');
+        _clear_cache($scfg->{api_host} || $scfg->{storeid} || 'unknown');
 
         # Fallback: re-fetch if create response didn't include lunid
         if (!defined $lun) {
@@ -4539,7 +4545,7 @@ sub _free_image_iscsi {
     if ($need_force_logout) {
         # Invalidate cache to get fresh targetextent data — a destination LUN may have been
         # created since the cache was last populated (e.g., during a disk move operation)
-        _clear_cache($scfg->{storeid} || 'unknown');
+        _clear_cache($scfg->{api_host} || $scfg->{storeid} || 'unknown');
         # Check how many LUNs are currently mapped to this target
         my $active_luns = 0;
         eval {
@@ -5247,11 +5253,12 @@ sub _ensure_target_visible {
     }
 
     # Step 4: Create extent for weight zvol if it doesn't exist
+    my $expected_disk = "zvol/$weight_zname";
     my $weight_extent_exists = 0;
     eval {
         my $extents = _tn_extents($scfg);
         for my $ext (@$extents) {
-            if (($ext->{name} // '') eq $weight_name) {
+            if (($ext->{name} // '') eq $weight_name && ($ext->{disk} // '') eq $expected_disk) {
                 $weight_extent_exists = 1;
                 last;
             }
@@ -5278,7 +5285,7 @@ sub _ensure_target_visible {
     eval {
         my $extents = _tn_extents($scfg);
         for my $ext (@$extents) {
-            if (($ext->{name} // '') eq $weight_name) {
+            if (($ext->{name} // '') eq $weight_name && ($ext->{disk} // '') eq $expected_disk) {
                 $weight_extent_id = $ext->{id};
                 last;
             }
@@ -5565,7 +5572,7 @@ sub _clone_image_iscsi {
         $lun = ref($tx) eq 'HASH' ? $tx->{lunid} : undef;
 
         # Invalidate cache after creating new mapping
-        _clear_cache($scfg->{storeid} || 'unknown');
+        _clear_cache($scfg->{api_host} || $scfg->{storeid} || 'unknown');
 
         # Fallback: re-fetch if create response didn't include lunid
         if (!defined $lun) {

--- a/TrueNASPlugin.pm
+++ b/TrueNASPlugin.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 
 # Plugin Version
-our $VERSION = '2.0.20';
+our $VERSION = '2.0.23';
 # Highest Proxmox storage API version this plugin is validated against.
 our $TESTED_APIVER = 13;
 use JSON::PP qw(encode_json decode_json);
@@ -41,9 +41,6 @@ package PVE::Storage::Custom::TrueNASPlugin;
 # Simple cache for API results (static data)
 my %API_CACHE = ();
 my $CACHE_TTL = 60; # 60 seconds
-
-# Per-process cache for _resolve_target_id results (avoids redundant API calls)
-my %_target_id_cache;
 
 # Per-host cache for preflight check results (time-based, 30s validity)
 my %_preflight_last_ok;
@@ -112,12 +109,10 @@ sub _clear_cache {
     if ($storage_id) {
         # Clear cache for specific storage (storage_id is api_host)
         delete $API_CACHE{$_} for grep { /^\Q$storage_id\E:/ } keys %API_CACHE;
-        delete $_target_id_cache{$_} for grep { /^\Q$storage_id\E:/ } keys %_target_id_cache;
         delete $_preflight_last_ok{$storage_id};
     } else {
         # Clear all cache
         %API_CACHE = ();
-        %_target_id_cache = ();
         %_preflight_last_ok = ();
     }
     # Also clear the portal sync cache (not scoped by api_host, clear entirely)
@@ -1955,8 +1950,16 @@ sub volume_snapshot_rollback {
         warn "Failed to clean up stale snapshot entries: $@" if $@;
     }
 
-    # Refresh initiator view
-    eval { PVE::Tools::run_command(['iscsiadm','-m','session','-R'], outfunc=>sub{}) };
+    # Refresh initiator view — rescan only this storage's target to avoid disrupting
+    # other active iSCSI sessions on unrelated volumes during the rollback
+    my $rollback_iqn = $scfg->{target_iqn};
+    eval {
+        if ($rollback_iqn) {
+            PVE::Tools::run_command(['iscsiadm','-m','node','-T',$rollback_iqn,'-R'], outfunc=>sub{});
+        } else {
+            PVE::Tools::run_command(['iscsiadm','-m','session','-R'], outfunc=>sub{});
+        }
+    };
     if ($scfg->{use_multipath}) {
         eval { PVE::Tools::run_command(['multipath','-r'], outfunc=>sub{}) };
     }
@@ -2311,12 +2314,13 @@ sub _resolve_target_id {
     my ($scfg) = @_;
     my $want = $scfg->{target_iqn} // die "target_iqn not set in storage.cfg\n";
     my $api_host = $scfg->{api_host} // '';
-    my $cache_key = "$api_host:$want";
 
-    # Return cached result if available
-    if (exists $_target_id_cache{$cache_key}) {
-        _log($scfg, 2, 'debug', "[TrueNAS] _resolve_target_id: using cached target_id=$_target_id_cache{$cache_key} for $want");
-        return $_target_id_cache{$cache_key};
+    # Use the TTL-based %API_CACHE (60s) so stale IDs are automatically refreshed
+    # and _clear_cache() always invalidates this alongside other cached data.
+    my $cached_id = _get_cached($api_host, "target_id:$want");
+    if (defined $cached_id) {
+        _log($scfg, 2, 'debug', "[TrueNAS] _resolve_target_id: using cached target_id=$cached_id for $want");
+        return $cached_id;
     }
 
     # 1) Get targets; if empty, surface a clear diagnostic
@@ -2386,8 +2390,7 @@ sub _resolve_target_id {
             $want
         );
     }
-    $_target_id_cache{$cache_key} = $found->{id};
-    return $found->{id};
+    return _set_cache($api_host, "target_id:$want", $found->{id});
 }
 
 # ======== Portal normalization & reachability ========
@@ -4186,15 +4189,25 @@ sub _alloc_image_iscsi {
     };
     my $extent_id;
     {
-        my $ext = _api_call(
-            $scfg,
-            'iscsi.extent.create',
-            [ $extent_payload ],
-        );
+        my $ext = eval {
+            _api_call(
+                $scfg,
+                'iscsi.extent.create',
+                [ $extent_payload ],
+            );
+        };
+        if ($@) {
+            # Cleanup: delete the zvol if extent creation failed
+            eval { _tn_dataset_delete($scfg, $full_ds) };
+            die "Failed to create iSCSI extent for disk '$zname': $@\n";
+        }
         # normalize id from WebSocket result (hashref)
         $extent_id = ref($ext) eq 'HASH' ? $ext->{id} : $ext;
+        # Invalidate cache so subsequent targetextents lookup sees current state
+        _clear_cache($scfg->{api_host} || $scfg->{storeid} || 'unknown');
     }
     if (!defined $extent_id) {
+        eval { _tn_dataset_delete($scfg, $full_ds) };
         die sprintf(
             "Failed to create iSCSI extent for disk '%s'\n\n" .
             "Dataset: %s\n" .
@@ -4214,27 +4227,22 @@ sub _alloc_image_iscsi {
         );
     }
 
-    # 3) Map extent to our shared target (targetextent.create); lunid is auto-assigned if not given
+    # 3) Map extent to our shared target via _tn_targetextent_create.
+    # This wrapper handles idempotency and "Extent is already in use" recovery
+    # for concurrent-node races, so no separate pre-check is needed.
     my $target_id = _resolve_target_id($scfg);
 
-    # First check if this mapping already exists
-    my $maps = _tn_targetextents($scfg) // [];
-    my ($existing_map) = grep {
-        (($_->{target}//-1) == $target_id) && (($_->{extent}//-1) == $extent_id)
-    } @$maps;
-
     my $lun;
-    if (!$existing_map) {
-        # Mapping doesn't exist, create it
-        _log($scfg, 2, 'debug', "[TrueNAS] alloc_image: creating target-extent mapping for extent_id=$extent_id to target_id=$target_id");
-        my $tx_payload = { target => $target_id, extent => $extent_id };
-        my $tx = _api_call(
-            $scfg,
-            'iscsi.targetextent.create',
-            [ $tx_payload ],
-        );
+    {
+        my $tx = eval { _tn_targetextent_create($scfg, $target_id, $extent_id, undef) };
+        if ($@) {
+            # Cleanup: delete extent and zvol if mapping creation failed
+            eval { _api_call_write($scfg, 'iscsi.extent.delete', [$extent_id]) };
+            eval { _tn_dataset_delete($scfg, $full_ds) };
+            die "Failed to create target-extent mapping for disk '$zname': $@\n";
+        }
 
-        # Extract LUN directly from create response (avoids a re-fetch query)
+        # Extract LUN from the returned mapping object
         $lun = ref($tx) eq 'HASH' ? $tx->{lunid} : undef;
 
         # Invalidate cache after creating new mapping
@@ -4242,23 +4250,19 @@ sub _alloc_image_iscsi {
 
         # Fallback: re-fetch if create response didn't include lunid
         if (!defined $lun) {
-            $maps = _tn_targetextents($scfg) // [];
-            ($existing_map) = grep {
+            my $maps = _tn_targetextents($scfg) // [];
+            my ($existing_map) = grep {
                 (($_->{target}//-1) == $target_id) && (($_->{extent}//-1) == $extent_id)
             } @$maps;
             $lun = $existing_map->{lunid} if $existing_map;
         }
-    } else {
-        _log($scfg, 1, 'info', "[TrueNAS] alloc_image: target-extent mapping already exists for extent_id=$extent_id (LUN $existing_map->{lunid})");
-        $lun = $existing_map->{lunid};
     }
     if (!defined $lun) {
         die sprintf(
             "Could not determine assigned LUN for disk '%s'\n\n" .
             "Target ID: %d\n" .
             "Extent ID: %d\n" .
-            "Extent name: %s\n" .
-            "Total target-extent mappings found: %d\n\n" .
+            "Extent name: %s\n\n" .
             "This usually means:\n" .
             "  1. Target-extent mapping creation failed silently\n" .
             "  2. TrueNAS cache not yet updated (rare)\n" .
@@ -4268,7 +4272,7 @@ sub _alloc_image_iscsi {
             "  - Verify extent '%s' is mapped to target ID %d\n" .
             "  - Check TrueNAS logs: /var/log/middlewared.log\n" .
             "  - Verify API has 'Sharing' read permissions\n",
-            $zname, $target_id, $extent_id, $zname, scalar(@$maps), $zname, $target_id
+            $zname, $target_id, $extent_id, $zname, $zname, $target_id
         );
     }
 
@@ -4339,14 +4343,24 @@ sub _alloc_image_nvme {
 
     # Create namespace on TrueNAS (locked section — API calls only)
     my $subsys_id = _nvme_ensure_subsystem($scfg);
-    my $ns = _api_call_write($scfg, 'nvmet.namespace.create', [{
-        device_type => 'ZVOL',
-        device_path => $zvol_path,
-        subsys_id => $subsys_id,
-        enabled => JSON::PP::true,
-    }]);
+    my $ns = eval {
+        _api_call_write($scfg, 'nvmet.namespace.create', [{
+            device_type => 'ZVOL',
+            device_path => $zvol_path,
+            subsys_id => $subsys_id,
+            enabled => JSON::PP::true,
+        }]);
+    };
+    if ($@) {
+        # Cleanup: delete the zvol if namespace creation failed
+        eval { _tn_dataset_delete($scfg, $full_ds) };
+        die "Failed to create NVMe namespace for disk '$zname': $@\n";
+    }
     my $device_uuid = $ns->{device_uuid};
-    die "Failed to get device_uuid from namespace creation\n" unless $device_uuid;
+    unless ($device_uuid) {
+        eval { _tn_dataset_delete($scfg, $full_ds) };
+        die "Failed to get device_uuid from namespace creation\n";
+    }
     _log($scfg, 1, 'info', "[TrueNAS] _alloc_image_nvme: created namespace with UUID $device_uuid");
 
     # Return volname immediately — defer connect + device discovery
@@ -4647,8 +4661,12 @@ sub _free_image_iscsi {
     # Handle any errors from dataset deletion
     if ($@) {
         my $err = $@ // '';
-        # Only warn if dataset actually exists - ENOENT means already cleaned up
-        warn "warning: delete dataset $full_ds failed: $err" unless $err =~ /does not exist|ENOENT|InstanceNotFound/i;
+        if ($err =~ /does not exist|ENOENT|InstanceNotFound/i) {
+            # Dataset already gone — treat as success (idempotent)
+        } else {
+            # Re-raise so Proxmox reports the failure; zvol is still present on TrueNAS
+            die "Failed to delete dataset $full_ds: $err\n";
+        }
     }
 
     # 6) Defer post-deletion cleanup after lock release (session rescan, self-healing, logout check)
@@ -4819,8 +4837,12 @@ sub _free_image_nvme {
     # Handle any errors from dataset deletion
     if ($@) {
         my $err = $@ // '';
-        # Only warn if dataset actually exists - ENOENT means already cleaned up
-        warn "warning: delete dataset $full_ds failed: $err" unless $err =~ /does not exist|ENOENT|InstanceNotFound/i;
+        if ($err =~ /does not exist|ENOENT|InstanceNotFound/i) {
+            # Dataset already gone — treat as success (idempotent)
+        } else {
+            # Re-raise so Proxmox reports the failure; zvol is still present on TrueNAS
+            die "Failed to delete dataset $full_ds: $err\n";
+        }
     }
 
     # 4) Defer udev cleanup after lock release
@@ -5263,16 +5285,24 @@ sub _ensure_target_visible {
         $weight_exists = 1 if $ds;
     };
 
+    my $weight_zvol_just_created = 0;  # tracks whether we created the zvol in this run (for L1 disk-path check in step 4)
     if (!$weight_exists) {
         _log($scfg, 1, 'info', "[TrueNAS] Pre-flight: creating weight zvol $weight_zname (1GB)");
         eval {
             _tn_dataset_create($scfg, $weight_zname, 1048576, '64K'); # 1GB in KiB
         };
         if ($@) {
-            _log($scfg, 0, 'err', "[TrueNAS] Pre-flight: failed to create weight zvol: $@");
-            die "Failed to create weight zvol: $@\n";
+            if ($@ =~ /already exists|dataset.*exist/i) {
+                # Concurrent create from another cluster node — zvol is present, continue
+                _log($scfg, 1, 'info', "[TrueNAS] Pre-flight: weight zvol $weight_zname already exists (concurrent create), continuing");
+            } else {
+                _log($scfg, 0, 'err', "[TrueNAS] Pre-flight: failed to create weight zvol: $@");
+                die "Failed to create weight zvol: $@\n";
+            }
+        } else {
+            $weight_zvol_just_created = 1;
+            _log($scfg, 1, 'info', "[TrueNAS] Pre-flight: weight zvol created");
         }
-        _log($scfg, 1, 'info', "[TrueNAS] Pre-flight: weight zvol created");
     } else {
         _log($scfg, 1, 'info', "[TrueNAS] Pre-flight: weight zvol already exists");
     }
@@ -5288,12 +5318,28 @@ sub _ensure_target_visible {
         my $extents = _tn_extents($scfg);
         for my $ext (@$extents) {
             my $ext_name = $ext->{name} // '';
-            if ($ext_name eq $weight_name) {
-                $found_weight_name = $weight_name;
-                last;
-            } elsif ($ext_name eq $weight_name_legacy) {
-                $found_weight_name = $weight_name_legacy;
-                _log($scfg, 1, 'info', "[TrueNAS] Pre-flight: using legacy weight extent '$weight_name_legacy' (pre-v2.0.20 name format; will continue working)");
+            if ($ext_name eq $weight_name || $ext_name eq $weight_name_legacy) {
+                # If we just created the weight zvol this run, verify the extent's disk path
+                # matches OUR zvol path. Two storages sharing the same IQN but using different
+                # datasets can end up with the extent pointing to a dead zvol from the other
+                # dataset (e.g., flash/pve vs nvme/pve). Delete the stale extent and recreate.
+                if ($weight_zvol_just_created && ($ext->{disk} // '') ne "zvol/$weight_zname") {
+                    _log($scfg, 1, 'info',
+                        "[TrueNAS] Pre-flight: weight extent '$ext_name' points to '$ext->{disk}' " .
+                        "but our zvol is at 'zvol/$weight_zname' — deleting stale extent for re-create");
+                    eval { _tn_extent_delete($scfg, $ext->{id}) };
+                    if ($@) {
+                        _log($scfg, 0, 'warning', "[TrueNAS] Pre-flight: failed to delete stale weight extent: $@");
+                        # Fall through: leave $found_weight_name unset so step 4 skips creation
+                        # (safer than a partially cleaned state). Next cycle will retry.
+                    }
+                    # $found_weight_name stays undef — step 4 will create a correct one
+                    last;
+                }
+                if ($ext_name eq $weight_name_legacy) {
+                    _log($scfg, 1, 'info', "[TrueNAS] Pre-flight: using legacy weight extent '$weight_name_legacy' (pre-v2.0.20 name format; will continue working)");
+                }
+                $found_weight_name = $ext_name;
                 last;
             }
         }
@@ -5323,6 +5369,14 @@ sub _ensure_target_visible {
     }
 
     # Step 5: Ensure extent is mapped to THIS target (not just any target).
+    # Force a fresh extent fetch here: if step 4 found the weight extent in the cache
+    # but the extent was subsequently deleted on TrueNAS, using the cached ID for
+    # iscsi.targetextent.create would trigger a FOREIGN KEY constraint failure.
+    # Always resolve the extent ID against live TrueNAS data before mapping.
+    {
+        my $_hk = $scfg->{api_host} || $scfg->{storeid} || 'unknown';
+        delete $API_CACHE{_cache_key($_hk, 'extents')};
+    }
     # Use $found_weight_name (may be legacy) so that lookups stay consistent with step 4.
     my $weight_mapped = 0;
     my $weight_extent_id;
@@ -5360,8 +5414,15 @@ sub _ensure_target_visible {
         _log($scfg, 1, 'info', "[TrueNAS] Pre-flight: removing stale weight extent mapping from wrong target (leftover from cache-collision bug)");
         eval { _tn_targetextent_delete($scfg, $stale_targetextent_id); };
         if ($@) {
-            _log($scfg, 0, 'warning', "[TrueNAS] Pre-flight: failed to remove stale weight mapping: $@");
-            $stale_delete_ok = 0;  # extent still locked to wrong target — skip create attempt
+            if ($@ =~ /InstanceNotFound|does not exist|not found/i) {
+                # Mapping was already deleted (concurrent cleanup from another node, or stale cache)
+                # — desired state achieved; clear cache and proceed with correct mapping create
+                _log($scfg, 1, 'info', "[TrueNAS] Pre-flight: stale mapping already gone (concurrent cleanup), continuing");
+                _clear_cache($scfg->{api_host} || $scfg->{storeid} || 'unknown');
+            } else {
+                _log($scfg, 0, 'warning', "[TrueNAS] Pre-flight: failed to remove stale weight mapping: $@");
+                $stale_delete_ok = 0;  # extent still locked to wrong target — skip create attempt
+            }
         } else {
             _log($scfg, 1, 'info', "[TrueNAS] Pre-flight: stale weight mapping removed");
         }
@@ -5377,10 +5438,20 @@ sub _ensure_target_visible {
                 _log($scfg, 1, 'info', "[TrueNAS] Pre-flight: LUN 0 in use, retrying weight mapping with auto-assigned LUN");
                 eval { _tn_targetextent_create($scfg, $target_id, $weight_extent_id, undef); };
                 if ($@) {
-                    _log($scfg, 0, 'warning', "[TrueNAS] Pre-flight: failed to map weight extent with auto LUN: $@");
+                    if ($@ =~ /FOREIGN KEY constraint failed|IntegrityError/i) {
+                        my $_hk = $scfg->{api_host} || $scfg->{storeid} || 'unknown';
+                        _log($scfg, 1, 'info', "[TrueNAS] Pre-flight: weight extent ID $weight_extent_id is stale (FOREIGN KEY), clearing cache for re-derive on next cycle");
+                        _clear_cache($_hk);
+                    } else {
+                        _log($scfg, 0, 'warning', "[TrueNAS] Pre-flight: failed to map weight extent with auto LUN: $@");
+                    }
                 } else {
                     _log($scfg, 1, 'info', "[TrueNAS] Pre-flight: weight extent mapped to target (auto LUN)");
                 }
+            } elsif ($@ =~ /FOREIGN KEY constraint failed|IntegrityError/i) {
+                my $_hk = $scfg->{api_host} || $scfg->{storeid} || 'unknown';
+                _log($scfg, 1, 'info', "[TrueNAS] Pre-flight: weight extent ID $weight_extent_id is stale (FOREIGN KEY), clearing cache for re-derive on next cycle");
+                _clear_cache($_hk);
             } else {
                 _log($scfg, 0, 'warning', "[TrueNAS] Pre-flight: failed to map weight extent: $@");
             }
@@ -5548,8 +5619,28 @@ sub _clone_image_iscsi {
 
     my $target_full = $scfg->{dataset} . '/' . $target_zname;
 
-    # 1) Create ZFS clone from snapshot
-    my $clone_result = _tn_dataset_clone($scfg, $source_snapshot, $target_full);
+    # 1) Create ZFS clone from snapshot, with retry on "already exists" TOCTOU race
+    # (two nodes picking the same free name between _find_free_disk_name and clone create)
+    my $clone_result;
+    {
+        my $max_clone_retries = 5;
+        my $clone_attempt = 0;
+        while ($clone_attempt < $max_clone_retries) {
+            $clone_attempt++;
+            $clone_result = eval { _tn_dataset_clone($scfg, $source_snapshot, $target_full) };
+            last unless $@;
+            if ($@ =~ /dataset already exists/i && !$name) {
+                # Race condition: name was taken between find and clone; pick a new one
+                _log($scfg, 1, 'warn', "[TrueNAS] _clone_image_iscsi: $target_full already exists (attempt $clone_attempt/$max_clone_retries), retrying with new name");
+                _clear_cache($scfg->{api_host} || $scfg->{storeid} || 'unknown');
+                $target_zname = _find_free_disk_name($scfg, $vmid);
+                $target_full  = $scfg->{dataset} . '/' . $target_zname;
+                next;
+            }
+            die $@;
+        }
+        die "Failed to create clone after $max_clone_retries attempts\n" if $clone_attempt >= $max_clone_retries && !defined $clone_result;
+    }
 
     # Wait for clone job to complete if it returned a job ID
     if (defined $clone_result && !ref($clone_result) && $clone_result =~ /^\d+$/) {
@@ -5598,41 +5689,27 @@ sub _clone_image_iscsi {
             die "Failed to create iSCSI extent for clone: $@\n";
         }
         $extent_id = ref($ext) eq 'HASH' ? $ext->{id} : $ext;
+        # Invalidate cache so the subsequent targetextents lookup sees current state
+        _clear_cache($scfg->{api_host} || $scfg->{storeid} || 'unknown');
     }
 
     die "failed to create extent for clone $target_zname\n" if !defined $extent_id;
 
-    # 3) Map extent to target
+    # 3) Map extent to target via _tn_targetextent_create (handles idempotency and
+    # "Extent is already in use" recovery for concurrent-node races)
     my $target_id = _resolve_target_id($scfg);
 
-    # First check if this mapping already exists
-    my $maps = _tn_targetextents($scfg) // [];
-    my ($existing_map) = grep {
-        (($_->{target}//-1) == $target_id) && (($_->{extent}//-1) == $extent_id)
-    } @$maps;
-
     my $lun;
-    if (!$existing_map) {
-        # Mapping doesn't exist, create it
-        _log($scfg, 2, 'debug', "[TrueNAS] _clone_image_iscsi: creating target-extent mapping for extent_id=$extent_id to target_id=$target_id");
-        my $tx_payload = { target => $target_id, extent => $extent_id };
-        my $tx = eval {
-            _api_call(
-                $scfg,
-                'iscsi.targetextent.create',
-                [ $tx_payload ],
-            );
-        };
+    {
+        my $tx = eval { _tn_targetextent_create($scfg, $target_id, $extent_id, undef) };
         if ($@) {
             # Cleanup: delete extent and zvol if mapping creation failed
-            eval {
-                _api_call($scfg, 'iscsi.extent.delete', [$extent_id]);
-            };
+            eval { _api_call_write($scfg, 'iscsi.extent.delete', [$extent_id]) };
             eval { _tn_dataset_delete($scfg, $target_full) };
             die "Failed to create target-extent mapping for clone: $@\n";
         }
 
-        # Extract LUN directly from create response (avoids a re-fetch query)
+        # Extract LUN from the returned mapping object
         $lun = ref($tx) eq 'HASH' ? $tx->{lunid} : undef;
 
         # Invalidate cache after creating new mapping
@@ -5640,15 +5717,12 @@ sub _clone_image_iscsi {
 
         # Fallback: re-fetch if create response didn't include lunid
         if (!defined $lun) {
-            $maps = _tn_targetextents($scfg) // [];
-            ($existing_map) = grep {
+            my $maps = _tn_targetextents($scfg) // [];
+            my ($existing_map) = grep {
                 (($_->{target}//-1) == $target_id) && (($_->{extent}//-1) == $extent_id)
             } @$maps;
             $lun = $existing_map->{lunid} if $existing_map;
         }
-    } else {
-        _log($scfg, 1, 'info', "[TrueNAS] _clone_image_iscsi: target-extent mapping already exists for extent_id=$extent_id (LUN $existing_map->{lunid})");
-        $lun = $existing_map->{lunid};
     }
 
     die "could not determine assigned LUN for clone $target_zname\n" if !defined $lun;
@@ -5688,8 +5762,26 @@ sub _clone_image_nvme {
 
     my $target_full = $scfg->{dataset} . '/' . $target_zname;
 
-    # 1) Create ZFS clone from snapshot
-    my $clone_result = _tn_dataset_clone($scfg, $source_snapshot, $target_full);
+    # 1) Create ZFS clone from snapshot, with retry on "already exists" TOCTOU race
+    my $clone_result;
+    {
+        my $max_clone_retries = 5;
+        my $clone_attempt = 0;
+        while ($clone_attempt < $max_clone_retries) {
+            $clone_attempt++;
+            $clone_result = eval { _tn_dataset_clone($scfg, $source_snapshot, $target_full) };
+            last unless $@;
+            if ($@ =~ /dataset already exists/i && !$name) {
+                _log($scfg, 1, 'warn', "[TrueNAS] _clone_image_nvme: $target_full already exists (attempt $clone_attempt/$max_clone_retries), retrying with new name");
+                _clear_cache($scfg->{api_host} || $scfg->{storeid} || 'unknown');
+                $target_zname = _find_free_disk_name($scfg, $vmid);
+                $target_full  = $scfg->{dataset} . '/' . $target_zname;
+                next;
+            }
+            die $@;
+        }
+        die "Failed to create clone after $max_clone_retries attempts\n" if $clone_attempt >= $max_clone_retries && !defined $clone_result;
+    }
 
     # Wait for clone job to complete if it returned a job ID
     if (defined $clone_result && !ref($clone_result) && $clone_result =~ /^\d+$/) {

--- a/TrueNASPlugin.pm
+++ b/TrueNASPlugin.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 
 # Plugin Version
-our $VERSION = '2.0.17';
+our $VERSION = '2.0.18';
 # Highest Proxmox storage API version this plugin is validated against.
 our $TESTED_APIVER = 13;
 use JSON::PP qw(encode_json decode_json);
@@ -2109,7 +2109,27 @@ sub _tn_targetextent_create($scfg, $target_id, $extent_id, $lun) {
     # Mapping doesn't exist, create it
     my $payload = { target => $target_id, extent => $extent_id };
     $payload->{lunid} = $lun if defined $lun;
-    my $result = _api_call_write($scfg, 'iscsi.targetextent.create', [ $payload ]);
+    my $result = eval { _api_call_write($scfg, 'iscsi.targetextent.create', [ $payload ]); };
+    my $err = $@;
+
+    if ($err) {
+        if ($err =~ /Extent is already in use/i) {
+            # Cache may be stale — force-refresh and check if already correctly mapped
+            # (can happen when another cluster node created the mapping after our cache was populated)
+            my $host_key = $scfg->{api_host} || $scfg->{storeid} || 'unknown';
+            _clear_cache($host_key);
+            my $fresh_maps = _tn_targetextents($scfg) // [];
+            my ($found) = grep {
+                (($_->{target}//-1) == $target_id) && (($_->{extent}//-1) == $extent_id)
+            } @$fresh_maps;
+            if ($found) {
+                _log($scfg, 2, 'debug', "[TrueNAS] Target-extent mapping already exists (stale cache) for extent_id=$extent_id (LUN $found->{lunid})");
+                return $found;
+            }
+        }
+        die $err;
+    }
+
     # Invalidate cache since targetextents list has changed
     _clear_cache($scfg->{api_host} || $scfg->{storeid} || 'unknown') if $result;
     return $result;
@@ -5303,6 +5323,7 @@ sub _ensure_target_visible {
                     } else {
                         # Mapped to wrong target — stale from cache-collision bug in older plugin versions
                         $stale_targetextent_id = $te->{id};
+                        last;
                     }
                 }
             }
@@ -5310,17 +5331,19 @@ sub _ensure_target_visible {
     };
 
     # Remove stale wrong-target mapping before creating the correct one
+    my $stale_delete_ok = 1;
     if ($stale_targetextent_id) {
         _log($scfg, 1, 'info', "[TrueNAS] Pre-flight: removing stale weight extent mapping from wrong target (leftover from cache-collision bug)");
         eval { _tn_targetextent_delete($scfg, $stale_targetextent_id); };
         if ($@) {
             _log($scfg, 0, 'warning', "[TrueNAS] Pre-flight: failed to remove stale weight mapping: $@");
+            $stale_delete_ok = 0;  # extent still locked to wrong target — skip create attempt
         } else {
             _log($scfg, 1, 'info', "[TrueNAS] Pre-flight: stale weight mapping removed");
         }
     }
 
-    if (!$weight_mapped && $weight_extent_id && $target_id) {
+    if (!$weight_mapped && $stale_delete_ok && $weight_extent_id && $target_id) {
         _log($scfg, 1, 'info', "[TrueNAS] Pre-flight: mapping weight extent to target");
         eval {
             _tn_targetextent_create($scfg, $target_id, $weight_extent_id, 0);

--- a/TrueNASPlugin.pm
+++ b/TrueNASPlugin.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 
 # Plugin Version
-our $VERSION = '2.0.23';
+our $VERSION = '2.0.24';
 # Highest Proxmox storage API version this plugin is validated against.
 our $TESTED_APIVER = 13;
 use JSON::PP qw(encode_json decode_json);
@@ -192,6 +192,11 @@ sub _normalize_blocksize {
 sub _is_retryable_error {
     my ($error) = @_;
     return 0 if !defined $error;
+
+    # Do NOT retry on database integrity errors — check BEFORE connection patterns
+    # because FK errors include Python traceback paths containing "connection.py"
+    # which would otherwise false-match the /connection.*failed/ pattern below
+    return 0 if $error =~ /FOREIGN KEY constraint failed|IntegrityError|constraint failed/i;
 
     # Retry on network errors, timeouts, connection issues
     return 1 if $error =~ /timeout|timed out/i;
@@ -5439,8 +5444,14 @@ sub _ensure_target_visible {
                 eval { _tn_targetextent_create($scfg, $target_id, $weight_extent_id, undef); };
                 if ($@) {
                     if ($@ =~ /FOREIGN KEY constraint failed|IntegrityError/i) {
+                        # Extent ID exists in TrueNAS query but not in SQLite — configfs/DB desync.
+                        # Delete the stale extent to force TrueNAS to resync; next cycle will recreate.
                         my $_hk = $scfg->{api_host} || $scfg->{storeid} || 'unknown';
-                        _log($scfg, 1, 'info', "[TrueNAS] Pre-flight: weight extent ID $weight_extent_id is stale (FOREIGN KEY), clearing cache for re-derive on next cycle");
+                        _log($scfg, 1, 'info', "[TrueNAS] Pre-flight: weight extent ID $weight_extent_id is stale (FK constraint failed), deleting to force resync");
+                        eval { _tn_extent_delete($scfg, $weight_extent_id) };
+                        if ($@) {
+                            _log($scfg, 1, 'info', "[TrueNAS] Pre-flight: stale extent delete failed (may already be gone): $@");
+                        }
                         _clear_cache($_hk);
                     } else {
                         _log($scfg, 0, 'warning', "[TrueNAS] Pre-flight: failed to map weight extent with auto LUN: $@");
@@ -5449,8 +5460,14 @@ sub _ensure_target_visible {
                     _log($scfg, 1, 'info', "[TrueNAS] Pre-flight: weight extent mapped to target (auto LUN)");
                 }
             } elsif ($@ =~ /FOREIGN KEY constraint failed|IntegrityError/i) {
+                # Extent ID exists in TrueNAS query but not in SQLite — configfs/DB desync.
+                # Delete the stale extent to force TrueNAS to resync; next cycle will recreate.
                 my $_hk = $scfg->{api_host} || $scfg->{storeid} || 'unknown';
-                _log($scfg, 1, 'info', "[TrueNAS] Pre-flight: weight extent ID $weight_extent_id is stale (FOREIGN KEY), clearing cache for re-derive on next cycle");
+                _log($scfg, 1, 'info', "[TrueNAS] Pre-flight: weight extent ID $weight_extent_id is stale (FK constraint failed), deleting to force resync");
+                eval { _tn_extent_delete($scfg, $weight_extent_id) };
+                if ($@) {
+                    _log($scfg, 1, 'info', "[TrueNAS] Pre-flight: stale extent delete failed (may already be gone): $@");
+                }
                 _clear_cache($_hk);
             } else {
                 _log($scfg, 0, 'warning', "[TrueNAS] Pre-flight: failed to map weight extent: $@");

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,14 @@
+truenas-proxmox-plugin (2.0.18+deb1) unstable; urgency=medium
+
+  * Fix "Extent is already in use" pre-flight failure in multi-node clusters:
+    _tn_targetextent_create now handles stale in-memory cache by force-refreshing
+    when TrueNAS reports "Extent is already in use", returning the existing mapping
+    if the extent is already correctly mapped to the target; prevents spurious
+    warnings when another cluster node created the weight mapping after the local
+    cache was last populated
+
+ -- TrueNAS Proxmox Plugin Maintainers <noreply@github.com>  Tue, 08 Apr 2026 00:00:00 +0000
+
 truenas-proxmox-plugin (2.0.17+deb1) unstable; urgency=medium
 
   * Fix stale weight extent mapping left by cache-collision bug: _ensure_target_visible

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,22 @@
+truenas-proxmox-plugin (2.0.20+deb1) unstable; urgency=medium
+
+  * Fix weight extent name collision across distinct iSCSI targets: append
+    8-char SHA1 of full IQN to weight extent name (pve-weight-<suffix>-<hash8>)
+    to prevent targets with colliding sanitized suffixes from sharing a weight
+    extent; legacy name format accepted via fallback lookup for existing clusters
+
+ -- TrueNAS Proxmox Plugin Maintainers <noreply@github.com>  Wed, 08 Apr 2026 00:00:00 +0000
+
+truenas-proxmox-plugin (2.0.19+deb1) unstable; urgency=medium
+
+  * Fix weight extent lookup failing when multiple storages share the same
+    iSCSI target: weight extent in _ensure_target_visible now matched by name
+    only (not name+disk), since the extent belongs to the target IQN and may
+    be created by a different storage with a different dataset path; also handle
+    "Extent name must be unique" gracefully as idempotent success
+
+ -- TrueNAS Proxmox Plugin Maintainers <noreply@github.com>  Wed, 08 Apr 2026 00:00:00 +0000
+
 truenas-proxmox-plugin (2.0.18+deb1) unstable; urgency=medium
 
   * Fix "Extent is already in use" pre-flight failure in multi-node clusters:

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,18 @@
+truenas-proxmox-plugin (2.0.27+deb1) unstable; urgency=medium
+
+  * Fix host-scoped cache key mismatches in preflight/target-id/NVMe portal
+    paths: use _cache_host_key consistently so targeted invalidation works
+    when api_host is unset
+  * Fix over-broad portal sync cache invalidation: clear portal-sync timestamp
+    only for the targeted host key on _clear_cache(storage_id)
+  * Refactor duplicated FK stale-extent recovery in _ensure_target_visible by
+    extracting shared _handle_fk_stale_extent helper
+  * Fix VM migration size mismatch (issue #25): alloc_image now steps
+    volblocksize down by powers of two to preserve exact requested bytes
+    instead of rounding zvol size upward
+
+ -- TrueNAS Proxmox Plugin Maintainers <noreply@github.com>  Sun, 13 Apr 2026 00:00:00 +0000
+
 truenas-proxmox-plugin (2.0.26+deb1) unstable; urgency=medium
 
   * Fix duplicate weight zvol creation when upgrading from pre-v2.0.20: step 2

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,19 @@
+truenas-proxmox-plugin (2.0.26+deb1) unstable; urgency=medium
+
+  * Fix duplicate weight zvol creation when upgrading from pre-v2.0.20: step 2
+    of _ensure_target_visible now checks for legacy-named zvol and reuses it
+    instead of creating a new hash-named duplicate (GitHub issue #27 follow-up)
+
+ -- TrueNAS Proxmox Plugin Maintainers <noreply@github.com>  Sat, 12 Apr 2026 00:00:00 +0000
+
+truenas-proxmox-plugin (2.0.25+deb1) unstable; urgency=low
+
+  * Code quality: Extract _cache_host_key and _invalidate_cache_key helpers
+  * Code quality: Use _api_call_write for extent creation (ephemeral connection)
+  * Code quality: Rename $stale_delete_ok to $stale_cleared
+
+ -- TrueNAS Proxmox Plugin Maintainers <noreply@github.com>  Sat, 12 Apr 2026 00:00:00 +0000
+
 truenas-proxmox-plugin (2.0.24+deb1) unstable; urgency=medium
 
   * Fix FK/IntegrityError causing unnecessary 3 retries before failing: check

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,20 @@
+truenas-proxmox-plugin (2.0.16+deb1) unstable; urgency=medium
+
+  * Fix extent/targetextent cache key collision: _tn_extents and _tn_targetextents
+    now key the API cache by api_host instead of storeid, preventing cross-host
+    cache contamination when multiple storages share a TrueNAS host
+  * Fix weight extent name-only lookup in _ensure_target_visible: both extent
+    search loops now also match on the zvol disk path to prevent false positives
+    from same-named extents on different datasets
+  * Fix _resolve_target_id cache collision: %_target_id_cache is now keyed by
+    "api_host:iqn" instead of iqn alone; _clear_cache deletes only matching
+    entries rather than wiping the entire hash
+  * Fix $_preflight_last_ok shared across all storages: converted to a per-host
+    hash %_preflight_last_ok keyed by api_host; _clear_cache clears only the
+    affected host entry
+
+ -- TrueNAS Proxmox Plugin Maintainers <noreply@github.com>  Mon, 07 Apr 2026 00:00:00 +0000
+
 truenas-proxmox-plugin (2.0.15+deb1) unstable; urgency=medium
 
   * Always force-delete iSCSI targetextent/extent in free_image to fix cluster

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+truenas-proxmox-plugin (2.0.17+deb1) unstable; urgency=medium
+
+  * Fix stale weight extent mapping left by cache-collision bug: _ensure_target_visible
+    now detects a weight extent mapped to the wrong target (created by older plugin
+    versions with the cache-collision bug), removes the stale mapping, and creates
+    the correct one; fixes "Extent is already in use" errors on pre-flight after
+    upgrading from v2.0.16
+
+ -- TrueNAS Proxmox Plugin Maintainers <noreply@github.com>  Mon, 07 Apr 2026 00:00:00 +0000
+
 truenas-proxmox-plugin (2.0.16+deb1) unstable; urgency=medium
 
   * Fix extent/targetextent cache key collision: _tn_extents and _tn_targetextents

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,44 @@
+truenas-proxmox-plugin (2.0.23+deb1) unstable; urgency=medium
+
+  * Fix extent delete in alloc/clone cleanup paths using read-path WebSocket
+    connection: _api_call replaced with _api_call_write for iscsi.extent.delete
+    in _alloc_image_iscsi and _clone_image_iscsi cleanup branches so failure is
+    not silently swallowed on persistent-connection setups
+  * Fix clone retry loop exhausting budget on warm dataset cache: invalidate
+    cache before _find_free_disk_name in retry branch of _clone_image_iscsi
+    and _clone_image_nvme so a fresh name is always resolved on collision
+
+ -- TrueNAS Proxmox Plugin Maintainers <noreply@github.com>  Fri, 11 Apr 2026 00:00:00 +0000
+
+truenas-proxmox-plugin (2.0.22+deb1) unstable; urgency=medium
+
+  * Fix orphaned zvol/extent in _alloc_image_iscsi: wrap extent.create and
+    targetextent.create in eval with cascading cleanup; replace bare _api_call
+    with _tn_targetextent_create for concurrent-node race recovery (C1)
+  * Fix silent zvol leak in free_image: re-raise non-"not found" dataset
+    deletion errors so Proxmox reports the failure (C2)
+  * Fix concurrent weight zvol create hard-dying in _ensure_target_visible:
+    treat "already exists" as idempotent success (M1)
+  * Fix _clone_image_iscsi missing _clear_cache and bare targetextent create (M2)
+  * Fix stale-mapping delete "not found" blocking correct mapping create (M3)
+  * Fix weight extent pointing to dead zvol after cross-dataset re-create (L1)
+  * Fix orphaned zvol in _alloc_image_nvme on namespace create failure (L2)
+  * Fix missing retry loop for "dataset already exists" in clone_image (L3)
+  * Fix _resolve_target_id process-lifetime cache: migrate to 60s TTL (L4)
+  * Fix global iSCSI rescan in volume_snapshot_rollback: scope to target IQN (L5)
+
+ -- TrueNAS Proxmox Plugin Maintainers <noreply@github.com>  Thu, 10 Apr 2026 00:00:00 +0000
+
+truenas-proxmox-plugin (2.0.21+deb1) unstable; urgency=medium
+
+  * Fix FOREIGN KEY constraint failure when weight extent is deleted between
+    cache population and mapping: force-invalidate extents cache before step 5
+    ID lookup in _ensure_target_visible so stale cached IDs are never used for
+    iscsi.targetextent.create; add FOREIGN KEY error detection in mapping path
+    with cache-clearing recovery
+
+ -- TrueNAS Proxmox Plugin Maintainers <noreply@github.com>  Thu, 10 Apr 2026 00:00:00 +0000
+
 truenas-proxmox-plugin (2.0.20+deb1) unstable; urgency=medium
 
   * Fix weight extent name collision across distinct iSCSI targets: append

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,14 @@
+truenas-proxmox-plugin (2.0.24+deb1) unstable; urgency=medium
+
+  * Fix FK/IntegrityError causing unnecessary 3 retries before failing: check
+    database integrity patterns before connection patterns in _is_retryable_error
+    to prevent Python traceback paths like "connection.py" false-matching
+  * Fix weight extent FK constraint failure not cleaning TrueNAS state: attempt
+    to delete stale extent on FK failure to force configfs/DB resync instead of
+    only clearing plugin cache (which left TrueNAS in inconsistent state)
+
+ -- TrueNAS Proxmox Plugin Maintainers <noreply@github.com>  Sat, 12 Apr 2026 00:00:00 +0000
+
 truenas-proxmox-plugin (2.0.23+deb1) unstable; urgency=medium
 
   * Fix extent delete in alloc/clone cleanup paths using read-path WebSocket

--- a/wiki/Changelog.md
+++ b/wiki/Changelog.md
@@ -1,5 +1,14 @@
 # TrueNAS Plugin Changelog
 
+## Version 2.0.24 (April 12, 2026)
+
+### Bug Fixes
+
+- **Fix FK/IntegrityError causing unnecessary 3 retries (7+ seconds) before failing (GitHub issue #27)**: The `_is_retryable_error` function's `/connection.*failed/i` pattern matched FK constraint errors because the JSON-encoded Python traceback contains file paths like `datastore/connection.py` and later "constraint **failed**". Since `encode_json` produces one long string (newlines become `\n` literals), the `.` bridged across everything. FK/IntegrityError patterns are now checked first before connection patterns, eliminating wasted retry cycles.
+- **Fix weight extent FK constraint failure only clearing cache instead of fixing TrueNAS state (GitHub issue #27)**: When `iscsi.extent.query` returned an extent ID that didn't exist in SQLite (TrueNAS configfs/DB desync), the pre-flight's FK handler only cleared the plugin's cache. On the next cycle, the same stale extent ID would be returned and fail again. The FK handler now attempts to delete the stale extent from TrueNAS to force a resync; the next cycle will recreate it cleanly.
+
+---
+
 ## Version 2.0.23 (April 11, 2026)
 
 ### Bug Fixes

--- a/wiki/Changelog.md
+++ b/wiki/Changelog.md
@@ -1,5 +1,39 @@
 # TrueNAS Plugin Changelog
 
+## Version 2.0.23 (April 11, 2026)
+
+### Bug Fixes
+
+- **Fix extent delete in `_alloc_image_iscsi` and `_clone_image_iscsi` cleanup paths using read-path WebSocket connection**: The `eval { _api_call(..., 'iscsi.extent.delete', ...) }` cleanup calls on targetextent mapping failure used `_api_call` (persistent read-path connection) instead of `_api_call_write` (ephemeral write-path connection). On a persistent-connection setup this could fail silently, leaving an orphaned extent on TrueNAS. Both cleanup paths now use `_api_call_write`, consistent with `_tn_extent_delete`.
+- **Fix clone retry loop exhausting budget on cached "dataset already exists" collision**: `_clone_image_iscsi` and `_clone_image_nvme` retry loops called `_find_free_disk_name` without first clearing the 60s TTL dataset cache. If the cache was still warm, the same name could be returned on successive attempts, burning all retry attempts against the same collision. The cache is now invalidated before each `_find_free_disk_name` call in the retry branch.
+
+---
+
+## Version 2.0.22 (April 10, 2026)
+
+### Bug Fixes
+
+- **Fix orphaned zvol/extent when `_alloc_image_iscsi` fails mid-allocation (C1)**: `iscsi.extent.create` and `iscsi.targetextent.create` were bare unguarded calls — any API throw (network drop, retry exhaustion) left the zvol and/or extent on TrueNAS with no Proxmox record. Both calls are now wrapped in `eval` with cascading cleanup on failure (delete extent → delete zvol). The bare `_api_call` for targetextent has been replaced with `_tn_targetextent_create`, which handles idempotency and "Extent is already in use" recovery for concurrent-node races.
+- **Fix silent zvol leak when dataset deletion fails in `free_image` (C2)**: The `eval { _delete_dataset_with_retry }` block was followed by a `warn` on any error, causing `free_image` to return success to Proxmox even when the zvol was still present on TrueNAS. Non-"not found" errors now `die` so Proxmox surfaces the failure. Applies to both iSCSI and NVMe paths.
+- **Fix concurrent weight zvol create causing hard `die` in `_ensure_target_visible` step 2 (M1)**: On cluster startup, two nodes race to create the weight zvol. The loser hit an unconditional `die`, skipping extent creation and mapping for that node. "Dataset already exists" errors are now treated as success (the zvol is present — desired state achieved).
+- **Fix `_clone_image_iscsi` using bare `_api_call` for targetextent create (M2)**: Added `_clear_cache` after extent create so the targetextents lookup uses fresh data; replaced bare `_api_call` for targetextent create with `_tn_targetextent_create` for proper "already in use" recovery.
+- **Fix concurrent stale-mapping delete causing `$stale_delete_ok=0` (M3)**: When two nodes raced to delete the same stale wrong-target weight mapping (post cache-collision bug upgrade), the second node got a "not found" error which set `$stale_delete_ok = 0`, preventing the correct mapping from being created. "Not found" class errors from the stale delete are now treated as success (the mapping is gone — desired state).
+- **Fix weight extent pointing to dead zvol path after cross-dataset zvol re-create (L1)**: Two storages sharing the same IQN but different datasets could leave the weight extent pointing to a deleted zvol from one storage's dataset while the other storage created an orphan zvol at its own dataset path. Step 4 now checks the extent's disk path against the current storage's expected path when the zvol was just created, and deletes stale extents for re-creation.
+- **Fix orphaned zvol when `_alloc_image_nvme` namespace create fails (L2)**: `nvmet.namespace.create` was an unguarded call — any throw left the zvol orphaned. Now wrapped in `eval` with zvol cleanup on failure.
+- **Fix missing retry loop for "dataset already exists" in `clone_image` (L3)**: `_clone_image_iscsi` and `_clone_image_nvme` called `_find_free_disk_name` then immediately attempted the clone with no retry, unlike `alloc_image` which has a 5-attempt retry loop. Concurrent template deployments could fail permanently on the TOCTOU race. Both functions now retry up to 5 times with a fresh name on "dataset already exists".
+- **Fix `_resolve_target_id` using process-lifetime cache with no TTL (L4)**: The `%_target_id_cache` hash had no TTL — if a TrueNAS target was deleted and recreated with a new integer ID, all subsequent writes would use the stale ID and fail with FOREIGN KEY errors until the process restarted. Target ID lookups are now backed by `_get_cached`/`_set_cache` (60s TTL), consistent with all other API caches, and `_clear_cache` invalidates them automatically.
+- **Fix global iSCSI session rescan in `volume_snapshot_rollback` (L5)**: `iscsiadm -m session -R` rescanned all iSCSI sessions on the node, potentially disrupting I/O on unrelated volumes during a snapshot rollback. Now uses `iscsiadm -m node -T <iqn> -R` to rescan only the target IQN associated with the storage being rolled back.
+
+---
+
+## Version 2.0.21 (April 10, 2026)
+
+### Bug Fixes
+
+- **Fix FOREIGN KEY constraint failure when weight extent is deleted between cache population and mapping (GitHub issue #27 follow-up)**: `_ensure_target_visible` used a 60-second cached extent list in step 5 to look up the weight extent's numeric ID. If the weight extent was deleted from TrueNAS after step 4's (possibly cached) lookup — e.g., by a manual cleanup, a test cycle, or a TrueNAS service restart — step 5 would resolve a stale ID and `iscsi.targetextent.create` would fail with `sqlite3.IntegrityError: FOREIGN KEY constraint failed`. The extents cache is now force-invalidated before the step 5 ID lookup so we always resolve the current TrueNAS state. As defense in depth, FOREIGN KEY errors in the mapping path are also detected explicitly, the cache is cleared, and a recovery log message is emitted instead of a generic warning.
+
+---
+
 ## Version 2.0.20 (April 8, 2026)
 
 ### Bug Fixes

--- a/wiki/Changelog.md
+++ b/wiki/Changelog.md
@@ -1,5 +1,24 @@
 # TrueNAS Plugin Changelog
 
+## Version 2.0.26 (April 12, 2026)
+
+### Bug Fixes
+
+- **Fix duplicate weight zvol creation when upgrading from pre-v2.0.20 (GitHub issue #27 follow-up)**: When upgrading from a pre-v2.0.20 plugin that used legacy weight zvol names (e.g., `pve-weight-target-name`) to v2.0.20+ with hash-based names (e.g., `pve-weight-target-name-a3f7c2d1`), the plugin would create a new hash-named zvol even though the legacy zvol already existed. This caused: (1) duplicate 1GB zvols on TrueNAS, (2) orphaned legacy zvols that were never cleaned up, and (3) the legacy extent being deleted and recreated pointing to the new zvol. Step 2 of `_ensure_target_visible` now also checks for the legacy-named zvol; if found, it continues using it rather than creating a duplicate.
+
+---
+
+## Version 2.0.25 (April 12, 2026)
+
+### Code Quality
+
+- **Extract `_cache_host_key` helper**: Consolidated 19 occurrences of `$scfg->{api_host} || $scfg->{storeid} || 'unknown'` into a single helper function for consistency and maintainability.
+- **Extract `_invalidate_cache_key` helper**: Targeted cache invalidation now uses a helper instead of direct `%API_CACHE` manipulation.
+- **Fix `_api_call` vs `_api_call_write` inconsistency**: Extent creation in `_alloc_image_iscsi` and `_clone_image_iscsi` now uses `_api_call_write` (ephemeral connection) consistent with other write operations.
+- **Rename `$stale_delete_ok` to `$stale_cleared`**: Improved variable naming clarity in `_ensure_target_visible`.
+
+---
+
 ## Version 2.0.24 (April 12, 2026)
 
 ### Bug Fixes

--- a/wiki/Changelog.md
+++ b/wiki/Changelog.md
@@ -1,5 +1,21 @@
 # TrueNAS Plugin Changelog
 
+## Version 2.0.20 (April 8, 2026)
+
+### Bug Fixes
+
+- **Fix weight extent name collision across distinct iSCSI targets (GitHub issue #27 follow-up)**: The weight extent name was derived only from the sanitized IQN suffix (e.g., `iqn...ctl:target-foo-bar` → `pve-weight-target-foo-bar`). Two targets whose suffixes differ only in punctuation would produce the same name and, with the v2.0.19 name-only lookup, silently share a weight extent. The name now includes an 8-character SHA1 prefix of the full IQN (e.g., `pve-weight-target-foo-bar-a3f7c2d1`), making it cryptographically unique per target. Existing clusters with legacy-named weight extents continue to work via a fallback lookup that accepts the old format.
+
+---
+
+## Version 2.0.19 (April 8, 2026)
+
+### Bug Fixes
+
+- **Fix weight extent lookup failing when multiple storages share the same iSCSI target (GitHub issue #27 follow-up)**: `_ensure_target_visible` matched the weight extent by both name **and** disk path. When two storages use the same target IQN (e.g., `conexum-infrastructure`) but different datasets, the second storage could not find the weight extent created by the first (different disk path), attempted to create a duplicate, and hit TrueNAS's "Extent name must be unique" validation error. Weight extents are now matched by name only since they belong to the iSCSI target, not the dataset. The "Extent name must be unique" error during create is also handled gracefully as idempotent success.
+
+---
+
 ## Version 2.0.18 (April 8, 2026)
 
 ### Bug Fixes

--- a/wiki/Changelog.md
+++ b/wiki/Changelog.md
@@ -1,5 +1,13 @@
 # TrueNAS Plugin Changelog
 
+## Version 2.0.17 (April 7, 2026)
+
+### Bug Fixes
+
+- **Fix stale weight extent mapping left by cache-collision bug (GitHub issue #27 follow-up)**: After upgrading from the v2.0.16 cache-collision fix, users with a corrupted TrueNAS state (weight extent mapped to the wrong target by the old plugin) would hit `Extent is already in use` errors on every pre-flight. `_ensure_target_visible` now detects a weight extent mapped to any target other than the expected one, removes the stale mapping, and creates the correct one
+
+---
+
 ## Version 2.0.16 (April 7, 2026)
 
 ### Bug Fixes

--- a/wiki/Changelog.md
+++ b/wiki/Changelog.md
@@ -1,6 +1,14 @@
 # TrueNAS Plugin Changelog
 
-## Version 2.0.17 (April 7, 2026)
+## Version 2.0.18 (April 8, 2026)
+
+### Bug Fixes
+
+- **Fix `Extent is already in use` pre-flight failure in multi-node clusters (GitHub issue #27 follow-up)**: `_tn_targetextent_create` now handles the case where the weight extent is already correctly mapped but the in-memory cache was stale (e.g., another cluster node created the mapping after the local cache was last populated). When `Extent is already in use` is returned, the cache is force-refreshed and if the extent is found correctly mapped to the requested target, it returns the existing mapping as idempotent success instead of propagating an error
+
+---
+
+## Version 2.0.17 (April 8, 2026)
 
 ### Bug Fixes
 

--- a/wiki/Changelog.md
+++ b/wiki/Changelog.md
@@ -1,5 +1,19 @@
 # TrueNAS Plugin Changelog
 
+## Version 2.0.16 (April 7, 2026)
+
+### Bug Fixes
+
+- **Fix extent/targetextent cache key collision across multiple TrueNAS hosts**: `_tn_extents` and `_tn_targetextents` now key the API result cache by `api_host` instead of `storeid`. Previously, two storage configurations pointing to different TrueNAS hosts but using the same `storeid` would share a single cache slot, causing one host's extents to be returned for the other
+
+- **Fix weight extent name-only lookup in `_ensure_target_visible`**: Both loops that check for and retrieve the weight extent ID now additionally match on the zvol disk path (`disk` field = `zvol/<dataset>/<weight_name>`). Previously, a same-named extent on a different dataset (e.g., from another storage sharing the same TrueNAS host) could be mistakenly matched, causing the wrong extent to be mapped to the target
+
+- **Fix target ID cache collision across multiple TrueNAS hosts in `_resolve_target_id`**: The in-process `%_target_id_cache` is now keyed by `"$api_host:$iqn"` instead of `$iqn` alone. Previously, identical IQNs configured against different TrueNAS hosts would share the same cache slot, returning a stale target ID from the wrong host. `_clear_cache` now removes only entries matching the given api_host prefix rather than wiping the entire hash
+
+- **Fix `$_preflight_last_ok` shared across all storages**: Converted the global scalar `$_preflight_last_ok` to a per-host hash `%_preflight_last_ok` keyed by `api_host`. Previously, a successful preflight on any one storage would suppress preflight checks on all other storages for 30 seconds, potentially masking service-down or misconfiguration on a different TrueNAS host. `_clear_cache` now deletes only the entry for the affected host
+
+---
+
 ## Version 2.0.15 (April 3, 2026)
 
 ### Bug Fixes

--- a/wiki/Changelog.md
+++ b/wiki/Changelog.md
@@ -1,5 +1,16 @@
 # TrueNAS Plugin Changelog
 
+## Version 2.0.27 (April 13, 2026)
+
+### Bug Fixes
+
+- **Fix host-scoped cache key mismatches introduced during issue #27 follow-up hardening**: `_preflight_check_alloc`, `_resolve_target_id`, and `_nvme_sync_portals` now consistently use `_cache_host_key($scfg)` so per-host cache entries are invalidated correctly even when `api_host` is unset.
+- **Fix over-broad portal sync cache invalidation**: `_clear_cache($storage_id)` now clears `%_portal_sync_last_ok` only for the targeted host key instead of wiping all hosts, preventing unnecessary NVMe portal re-syncs across unrelated storages.
+- **Refactor duplicated FK stale-extent recovery path**: extracted `_handle_fk_stale_extent` helper and replaced duplicate in-branch blocks in `_ensure_target_visible` with shared logic.
+- **Fix VM migration size mismatch from zvol byte-rounding behavior (issue #25)**: `alloc_image` now preserves requested size exactly and steps `volblocksize` down by powers of two (to a 512-byte floor) when needed, instead of rounding zvol size up. This avoids QEMU drive-mirror size mismatches during migration.
+
+---
+
 ## Version 2.0.26 (April 12, 2026)
 
 ### Bug Fixes

--- a/wiki/README.md
+++ b/wiki/README.md
@@ -170,6 +170,6 @@ For issues not covered in documentation:
 
 ## Version Information
 
-**Version**: 2.0.23
-**Last Updated**: April 11, 2026
+**Version**: 2.0.24
+**Last Updated**: April 12, 2026
 **Compatibility**: Proxmox VE 8.x+, TrueNAS SCALE 25.10+

--- a/wiki/README.md
+++ b/wiki/README.md
@@ -170,6 +170,6 @@ For issues not covered in documentation:
 
 ## Version Information
 
-**Version**: 2.0.16
+**Version**: 2.0.17
 **Last Updated**: April 7, 2026
 **Compatibility**: Proxmox VE 8.x+, TrueNAS SCALE 25.10+

--- a/wiki/README.md
+++ b/wiki/README.md
@@ -170,6 +170,6 @@ For issues not covered in documentation:
 
 ## Version Information
 
-**Version**: 2.0.26
-**Last Updated**: April 12, 2026
+**Version**: 2.0.27
+**Last Updated**: April 13, 2026
 **Compatibility**: Proxmox VE 8.x+, TrueNAS SCALE 25.10+

--- a/wiki/README.md
+++ b/wiki/README.md
@@ -170,6 +170,6 @@ For issues not covered in documentation:
 
 ## Version Information
 
-**Version**: 2.0.17
-**Last Updated**: April 7, 2026
+**Version**: 2.0.18
+**Last Updated**: April 8, 2026
 **Compatibility**: Proxmox VE 8.x+, TrueNAS SCALE 25.10+

--- a/wiki/README.md
+++ b/wiki/README.md
@@ -170,6 +170,6 @@ For issues not covered in documentation:
 
 ## Version Information
 
-**Version**: 2.0.15
-**Last Updated**: April 3, 2026
+**Version**: 2.0.16
+**Last Updated**: April 7, 2026
 **Compatibility**: Proxmox VE 8.x+, TrueNAS SCALE 25.10+

--- a/wiki/README.md
+++ b/wiki/README.md
@@ -170,6 +170,6 @@ For issues not covered in documentation:
 
 ## Version Information
 
-**Version**: 2.0.20
-**Last Updated**: April 8, 2026
+**Version**: 2.0.23
+**Last Updated**: April 11, 2026
 **Compatibility**: Proxmox VE 8.x+, TrueNAS SCALE 25.10+

--- a/wiki/README.md
+++ b/wiki/README.md
@@ -170,6 +170,6 @@ For issues not covered in documentation:
 
 ## Version Information
 
-**Version**: 2.0.24
+**Version**: 2.0.26
 **Last Updated**: April 12, 2026
 **Compatibility**: Proxmox VE 8.x+, TrueNAS SCALE 25.10+

--- a/wiki/README.md
+++ b/wiki/README.md
@@ -170,6 +170,6 @@ For issues not covered in documentation:
 
 ## Version Information
 
-**Version**: 2.0.18
+**Version**: 2.0.20
 **Last Updated**: April 8, 2026
 **Compatibility**: Proxmox VE 8.x+, TrueNAS SCALE 25.10+


### PR DESCRIPTION
## Summary

- **Fix host-scoped cache key mismatches** (`_preflight_check_alloc`, `_resolve_target_id`, `_nvme_sync_portals` now use `_cache_host_key` consistently — closes issue #27 follow-up)
- **Fix over-broad portal sync cache invalidation** — `_clear_cache` now clears only the targeted host key instead of wiping all hosts
- **Fix VM migration size mismatch from zvol byte-rounding (issue #25)** — `alloc_image` preserves requested size exactly, stepping `volblocksize` down by powers of two instead of rounding up
- **Fix FK/IntegrityError causing unnecessary 3 retries before failing** — FK patterns now checked before connection patterns in `_is_retryable_error`
- **Fix weight extent FK constraint failure only clearing cache instead of fixing TrueNAS state** — stale extent now deleted from TrueNAS to force resync
- **Fix duplicate weight zvol on upgrade from pre-v2.0.20** — step 2 of `_ensure_target_visible` now recognises legacy-named zvols
- **Fix cascade allocation failures, resource leaks, and concurrent cluster race conditions** (v2.0.23 — multiple C/M/L severity fixes)
- **Fix weight extent name collision across distinct iSCSI targets** — name now includes 8-char SHA1 prefix of full IQN (v2.0.20)
- **Refactor**: extracted `_cache_host_key`, `_invalidate_cache_key`, and `_handle_fk_stale_extent` helpers

## Test Plan
- [x] Allocate and free volumes on iSCSI storage
- [x] Allocate and free volumes on NVMe-TCP storage
- [x] Verify no duplicate weight zvols after upgrade from pre-v2.0.20
- [x] Verify FK errors do not trigger unnecessary retries
- [x] Verify VM live migration size matches on iSCSI storage (issue #25)
- [x] Verify multi-node cluster concurrent alloc does not produce cache cross-contamination