### PR TITLE
Fix health check dataset type false positive

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -4713,10 +4713,10 @@ run_health_check() {
     # Check 4: Content type
     local content
     content=$(get_storage_config_value "$storage_name" "content")
-    if [[ "$content" == "images" ]]; then
-        check_result "Content type" "OK" "images"
+    if [[ "$content" == "images" || "$content" == "images,rootdir" || "$content" == "rootdir,images" ]]; then
+        check_result "Content type" "OK" "$content"
     elif [[ -n "$content" ]]; then
-        check_result "Content type" "WARNING" "$content (should be 'images')"
+        check_result "Content type" "WARNING" "$content (should include 'images' and optionally 'rootdir')"
     else
         check_result "Content type" "WARNING" "Not configured"
     fi
@@ -4827,7 +4827,7 @@ run_health_check() {
 
         # Make WebSocket API call to fetch dataset
         local dataset_info
-        dataset_info=$(tn_api_call "$api_host" "$api_key" "pool.dataset.query" "[[[\"id\",\"=\",\"$dataset\"]]]" 2>/dev/null)
+        dataset_info=$(tn_api_call "$api_host" "$api_key" "pool.dataset.query" "[[[\"id\",\"=\",\"$dataset\"]],{\"extra\":{\"retrieve_children\":false}}]" 2>/dev/null)
         local api_status=$?
 
         stop_spinner


### PR DESCRIPTION
## Summary
- Fix installer health check dataset type validation by querying the configured parent dataset without retrieving child zvols
- Treat `images,rootdir` / `rootdir,images` as valid content types now that LXC rootdir storage is supported
- Leave plugin release metadata unchanged because this is installer-only behavior

## Root cause
`pool.dataset.query` can return child datasets inline. The health check parsed the serialized response with a broad JSON grep/sed pipeline, so child zvol `VOLUME` entries could be interpreted as the configured parent dataset type and trigger a false critical error.

## Test plan
- [x] Created branch `fix/issue36-dataset-type-false-positive`
- [x] Copied modified `install.sh` to `root@10.15.14.195:/tmp/install-issue36-final.sh`
- [x] Ran `bash -n /tmp/install-issue36-final.sh` → `syntax: ok`
- [x] Ran `run_health_check tn-iscsi` → `Content type: ✓ images,rootdir`, `Dataset type: ✓ FILESYSTEM (correct)`
- [x] Ran `run_health_check tn-nvme` → `Content type: ✓ images,rootdir`, `Dataset type: ✓ FILESYSTEM (correct)`
- [x] Ran `run_health_check brexit` → `Content type: ✓ images,rootdir`, `Dataset type: ✓ FILESYSTEM (correct)`