### PR TITLE
Fix: Reject uppercase storage names to prevent TrueNAS API provisioning failure (issue #40)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -5531,12 +5531,14 @@ validate_ip() {
 # Validate storage name format (must match Proxmox PVE::JSONSchema::parse_id rules)
 validate_storage_name() {
     local name="$1"
-    # Must start with a letter, contain only letters/numbers/hyphens/underscores/dots,
-    # end with a letter or number, and be at least 2 characters
+    # Must start with a lowercase letter, contain only lowercase letters/numbers/hyphens/underscores/dots,
+    # end with a lowercase letter or number, and be at least 2 characters.
+    # Uppercase is rejected: TrueNAS SCALE enforces lowercase-only for iSCSI target and NVMe
+    # subsystem names, so an uppercase storage name would cause provisioning to fail at the API layer.
     if [[ ${#name} -lt 2 ]]; then
         return 1
     fi
-    if [[ $name =~ ^[a-zA-Z][a-zA-Z0-9_.-]*[a-zA-Z0-9]$ ]]; then
+    if [[ $name =~ ^[a-z][a-z0-9_.-]*[a-z0-9]$ ]]; then
         return 0
     fi
     return 1
@@ -7087,7 +7089,8 @@ generate_iqn() {
     year_month=$(date +%Y-%m)
 
     # Format: iqn.YYYY-MM.org.freenas.ctl:storage-name
-    echo "iqn.${year_month}.org.freenas.ctl:${storage_name}"
+    # Lowercase the suffix: TrueNAS SCALE enforces lowercase-only target names
+    echo "iqn.${year_month}.org.freenas.ctl:${storage_name,,}"
 }
 
 # Extract the short target name from an IQN
@@ -7354,7 +7357,8 @@ generate_nqn() {
     year_month=$(date +%Y-%m)
 
     # Format: nqn.YYYY-MM.org.freenas.ctl:storage-name
-    echo "nqn.${year_month}.org.freenas.ctl:${storage_name}"
+    # Lowercase the suffix: TrueNAS SCALE enforces lowercase-only subsystem names
+    echo "nqn.${year_month}.org.freenas.ctl:${storage_name,,}"
 }
 
 # Create an NVMe subsystem
@@ -9975,7 +9979,7 @@ wizard_add_storage() {
             continue
         fi
         if ! validate_storage_name "$WIZARD_STORAGE_NAME"; then
-            error "Invalid storage name. Must start with a letter, end with a letter or number, and contain only letters, numbers, hyphens, underscores, or dots (min 2 characters)"
+            error "Invalid storage name. Must start with a lowercase letter, end with a lowercase letter or number, and contain only lowercase letters, numbers, hyphens, underscores, or dots (min 2 characters)"
             continue
         fi
         if storage_name_exists "$WIZARD_STORAGE_NAME"; then


### PR DESCRIPTION
## Summary

Fixes #40 — uppercase characters in the Proxmox storage name cause provisioning to fail with a TrueNAS SCALE API `ValidationError`.

## Root Cause

`validate_storage_name` permitted uppercase letters (`[a-zA-Z]`). TrueNAS SCALE 25.10+ enforces lowercase-only for iSCSI target and NVMe subsystem names at the API layer:

```
ValidationErrors: Name can only contain lowercase alphanumeric characters
plus dot (.), dash (-), and colon (:)
```

So a storage name like `TNSSD-iscsi` passes the installer's validator, gets embedded verbatim into the generated IQN/NQN, and then TrueNAS rejects the `iscsi.target.create` call — leaving provisioning in a broken state with no clear error surfaced to the user.

## Reproduced in test environment

Three-point repro confirmed on PVE 9.x / TrueNAS SCALE 25.10.1:
1. `validate_storage_name('TNSSD-REPRO40')` → accepted (should reject)
2. `generate_iqn('TNSSD-REPRO40')` → IQN contains uppercase suffix
3. `iscsi.target.create {name: 'TNSSD-REPRO40'}` → TrueNAS returns `EINVAL` ValidationError

## Changes (install.sh only)

- **`validate_storage_name`**: regex tightened from `[a-zA-Z]` to `[a-z]` throughout — uppercase now rejected at the prompt with an updated error message explicitly stating lowercase-only
- **`generate_iqn`** / **`generate_nqn`**: apply `${var,,}` lowercasing to the storage name suffix as belt-and-suspenders for any future path that bypasses the validator
- Error message updated: *"Must start with a lowercase letter … contain only lowercase letters …"*

No changes to `TrueNASPlugin.pm`, docs, or version numbers — installer-only fix.