### PR TITLE
Bump TESTED_APIVER to 14 for PVE 9.2+ compatibility (issue #41)

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,6 @@ This project is provided as-is for use with Proxmox VE and TrueNAS SCALE.
 
 ---
 
-**Version**: 2.1.0
-**Last Updated**: May 7, 2026
+**Version**: 2.1.1
+**Last Updated**: May 29, 2026
 **Compatibility**: Proxmox VE 8.x+, TrueNAS SCALE 25.10+

--- a/TrueNASPlugin.pm
+++ b/TrueNASPlugin.pm
@@ -4,9 +4,9 @@ use strict;
 use warnings;
 
 # Plugin Version
-our $VERSION = '2.1.0';
+our $VERSION = '2.1.1';
 # Highest Proxmox storage API version this plugin is validated against.
-our $TESTED_APIVER = 13;
+our $TESTED_APIVER = 14;
 use JSON::PP qw(encode_json decode_json);
 use URI::Escape qw(uri_escape);
 use MIME::Base64 qw(encode_base64);
@@ -311,7 +311,7 @@ sub _retry_with_backoff {
 
 # ======== Storage plugin identity ========
 # Storage API version - dynamically adapts to PVE version
-# Supports PVE 8.x (APIVER 11) and PVE 9.x (APIVER 13)
+# Supports PVE 8.x (APIVER 11) and PVE 9.x (APIVER 14)
 sub api {
     my $tested_apiver = $TESTED_APIVER;  # Latest tested version (PVE 9.x)
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+truenas-proxmox-plugin (2.1.1+deb1) unstable; urgency=medium
+
+  * Bump storage API version to 14 to match libpve-storage-perl 9.1.3+
+    (Proxmox VE 9.2+); eliminates "implementing an older storage API" warning
+    on every plugin load (issue #41).
+
+ -- TrueNAS Proxmox Plugin Maintainers <noreply@github.com>  Thu, 29 May 2026 00:00:00 +0000
+
 truenas-proxmox-plugin (2.1.0+deb1) unstable; urgency=medium
 
   * Rename all storage.cfg option keys to tn_* prefix to avoid namespace

--- a/wiki/Changelog.md
+++ b/wiki/Changelog.md
@@ -1,5 +1,11 @@
 # TrueNAS Plugin Changelog
 
+## Version 2.1.1 (May 29, 2026)
+
+- **Bump storage API version to 14 (GitHub issue #41)**: Updated `$TESTED_APIVER` from 13 to 14 to match `libpve-storage-perl` 9.1.3+ (Proxmox VE 9.2+), eliminating the "implementing an older storage API" warning logged at every plugin load. The APIVER 14 bump in PVE was backward compatible (added optional `get_identity()` method); no new plugin methods are required.
+
+---
+
 ## Version 2.1.0 (May 7, 2026)
 
 ### Breaking Change

--- a/wiki/README.md
+++ b/wiki/README.md
@@ -170,6 +170,6 @@ For issues not covered in documentation:
 
 ## Version Information
 
-**Version**: 2.1.0
-**Last Updated**: May 7, 2026
+**Version**: 2.1.1
+**Last Updated**: May 29, 2026
 **Compatibility**: Proxmox VE 8.x+, TrueNAS SCALE 25.10+


### PR DESCRIPTION
## Summary

Fixes #41 — eliminates the `"Plugin ... is implementing an older storage API, an upgrade is recommended"` warning logged on every plugin load on Proxmox VE 9.2+.

## Root Cause

`libpve-storage-perl` 9.1.3 (shipped with PVE 9.2 / proxmox-ve 9.2.0) bumped `APIVER` from 13 → 14 to introduce the new optional `get_identity()` plugin method. `PVE::Storage` warns whenever a loaded plugin's `api()` return value doesn't match `APIVER` exactly, so all nodes in a cluster logged this warning continuously.

## Fix

Update `$TESTED_APIVER` from `13` to `14`. The PVE bump was explicitly marked backward compatible — `get_identity()` is optional and the base class stub (`die "not implemented"`) is the correct default for plugins that don't implement it. No new methods are required.

## Verification

Tested on Proxmox VE 9.2.0 (`libpve-storage-perl` 9.1.5):

```
$ perl -e 'use PVE::Storage; print "APIVER:", PVE::Storage::APIVER(), "\n";'
APIVER:14         # no warning
```