### PR TITLE
Fix NVMe/TCP connect failure when CPUs are offlined (issue #48)

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,6 @@ This project is provided as-is for use with Proxmox VE and TrueNAS SCALE.
 
 ---
 
-**Version**: 2.1.1
-**Last Updated**: May 29, 2026
+**Version**: 2.1.2
+**Last Updated**: June 3, 2026
 **Compatibility**: Proxmox VE 8.x+, TrueNAS SCALE 25.10+

--- a/TrueNASPlugin.pm
+++ b/TrueNASPlugin.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 
 # Plugin Version
-our $VERSION = '2.1.1';
+our $VERSION = '2.1.2';
 # Highest Proxmox storage API version this plugin is validated against.
 our $TESTED_APIVER = 14;
 use JSON::PP qw(encode_json decode_json);
@@ -512,6 +512,14 @@ sub properties {
             description => "Number of 100ms retries waiting for a block device to appear after connect.",
             type => 'integer', optional => 1, default => 200, minimum => 0, maximum => 600,
         },
+        tn_nr_io_queues => {
+            description => "Number of NVMe/TCP I/O queues per controller. When unset, " .
+                          "auto-detected: uses online CPU count when all CPUs are online, " .
+                          "or half of possible CPUs when any CPU is offline (avoids kernel " .
+                          "queue-to-CPU mapping failures with gapped CPU topologies, " .
+                          "see issue #48). Set manually if TrueNAS reports queue limit errors.",
+            type => 'integer', optional => 1, minimum => 1, maximum => 256,
+        },
     };
 }
 sub options {
@@ -584,6 +592,9 @@ sub options {
 
         # Device readiness
         tn_device_ready_retries => { optional => 1 },
+
+        # NVMe/TCP queue tuning
+        tn_nr_io_queues => { optional => 1 },
     };
 }
 
@@ -2968,6 +2979,27 @@ sub _nvme_is_connected {
     return $connected;
 }
 
+# Count CPUs listed in a sysfs range file (e.g. /sys/devices/system/cpu/online).
+# The file contains comma-separated ranges like "0-3,5,7-9".
+# Returns the total CPU count, or undef on read failure.
+sub _read_cpu_count {
+    my ($path) = @_;
+    open my $fh, '<', $path or return undef;
+    my $line = <$fh>;
+    close $fh;
+    return undef unless defined $line;
+    chomp $line;
+    my $count = 0;
+    for my $part (split /,/, $line) {
+        if ($part =~ /^(\d+)-(\d+)$/) {
+            $count += $2 - $1 + 1;
+        } elsif ($part =~ /^(\d+)$/) {
+            $count += 1;
+        }
+    }
+    return $count || undef;
+}
+
 # Connect to NVMe/TCP subsystem (all portals)
 sub _nvme_connect {
     my ($scfg) = @_;
@@ -3003,6 +3035,26 @@ sub _nvme_connect {
         _log($scfg, 2, 'debug', "[TrueNAS] nvme_connect: connecting to $host:$port");
 
         my @cmd = ('nvme', 'connect', '-t', 'tcp', '-n', $nqn, '-a', $host, '-s', $port);
+
+        # Cap I/O queues to avoid kernel queue-to-CPU mapping failures when CPUs are
+        # offlined (issue #48). The kernel maps queue N to CPU N by index; if a CPU in
+        # the possible range is offline, connecting with more queues than
+        # floor(possible/2) causes EXDEV (-18) because at least one queue has no online
+        # CPU in its affinity set. floor(possible/2) guarantees each queue maps to at
+        # least 2 possible CPUs, so one offline CPU never orphans a queue.
+        # When all CPUs are online (online == possible) we pass nproc, matching the
+        # kernel default. tn_nr_io_queues overrides both.
+        my $nr_io_queues;
+        if (defined $scfg->{tn_nr_io_queues}) {
+            $nr_io_queues = $scfg->{tn_nr_io_queues};
+        } else {
+            my $nr_conf   = _read_cpu_count('/sys/devices/system/cpu/possible');
+            my $nr_online = _read_cpu_count('/sys/devices/system/cpu/online');
+            $nr_io_queues = ($nr_conf && $nr_online && $nr_online < $nr_conf)
+                ? int($nr_conf / 2)
+                : $nr_online;
+        }
+        push @cmd, '--nr-io-queues', $nr_io_queues if $nr_io_queues && $nr_io_queues > 0;
 
         # Add host NQN if not default
         push @cmd, '--hostnqn', $hostnqn if $hostnqn;

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+truenas-proxmox-plugin (2.1.2+deb1) unstable; urgency=medium
+
+  * Fix NVMe/TCP connect failure when CPUs are offlined (issue #48): pass
+    --nr-io-queues to nvme connect to avoid kernel queue-to-CPU mapping
+    failures (EXDEV/-18) when CPU topology has gaps. Uses online CPU count
+    when all CPUs are online; floor(possible/2) when any CPU is offline.
+    Adds optional tn_nr_io_queues storage.cfg key (1-256) for manual override.
+
+ -- TrueNAS Proxmox Plugin Maintainers <noreply@github.com>  Wed, 03 Jun 2026 00:00:00 +0000
+
 truenas-proxmox-plugin (2.1.1+deb1) unstable; urgency=medium
 
   * Bump storage API version to 14 to match libpve-storage-perl 9.1.3+

--- a/tools/dev-truenas-plugin-full-function-test.sh
+++ b/tools/dev-truenas-plugin-full-function-test.sh
@@ -3626,6 +3626,14 @@ test_interrupted_operations() {
         track_timing "interrupted_ops_orphans" "$total_orphans"
     fi
 
+    # Wait for the storage CFS lock from test 1's interrupted allocation to release.
+    # The NVMe plugin holds the lock during its cleanup phase; under set -euo pipefail
+    # a blocked pvesh create produces empty output which previously crashed the script.
+    # parse_volid() now handles that gracefully, but waiting here lets test 2 actually
+    # succeed rather than skip due to lock contention.
+    log_info "Waiting 30s for storage lock to release after interrupted allocation..."
+    sleep 30
+
     # Test 2: Verify system can handle normal operations after interruption
     log_info "Test 2: Verifying normal operations after interruption"
     vmid=$((base_vmid + 1))

--- a/tools/dev-truenas-plugin-full-function-test.sh
+++ b/tools/dev-truenas-plugin-full-function-test.sh
@@ -670,6 +670,20 @@ destroy_lxc() {
     free_orphaned_disks_for_vmid "$vmid"
 }
 
+# Extract a storage:volid string from pvesh JSON output.
+# Returns empty string (never exits non-zero) so callers work under set -euo pipefail.
+parse_volid() {
+    # Accept JSON either as first argument or from stdin.
+    # Returns empty string (never exits non-zero) so callers work under set -euo pipefail.
+    local json
+    if [[ $# -gt 0 ]]; then
+        json="$1"
+        echo "$json"
+    else
+        cat
+    fi | sed -n 's/.*"\([^"]*\)".*/\1/p' | head -1 || true
+}
+
 free_orphaned_disks_for_vmid() {
     local vmid="$1"
     local disks
@@ -858,7 +872,7 @@ test_disk_allocation() {
         -vmid $vmid \
         -filename "vm-$vmid-disk-0" \
         -size "${size_gb}G" \
-        --output-format=json 2>&1 | sed -n 's/.*"\([^"]*\)".*/\1/p' | head -1)
+        --output-format=json 2>&1 | parse_volid)
 
     if [[ -z "$volid" ]] || [[ "$volid" == *"error"* ]]; then
         log_error "Failed to allocate disk"
@@ -1114,7 +1128,7 @@ test_create_base_vm_for_clone() {
         -vmid $vmid \
         -filename "vm-$vmid-disk-0" \
         -size "10G" \
-        --output-format=json 2>&1 | sed -n 's/.*"\([^"]*\)".*/\1/p' | head -1)
+        --output-format=json 2>&1 | parse_volid)
 
     if [[ -z "$volid" ]] || [[ "$volid" == *"error"* ]]; then
         log_error "Failed to allocate disk"
@@ -1313,7 +1327,7 @@ test_disk_resize() {
         -vmid "$vmid" \
         -filename "vm-${vmid}-disk-0" \
         -size "10G" \
-        --output-format=json 2>&1 | sed -n 's/.*"\([^"]*\)".*/\1/p' | head -1)
+        --output-format=json 2>&1 | parse_volid)
 
     if ! qm set "$vmid" -scsi0 "$volid" >/dev/null 2>&1; then
         log_error "Failed to attach disk"
@@ -1423,7 +1437,7 @@ test_concurrent_operations() {
                     -size "5G" \
                     --output-format=json 2>&1)
 
-                volid=$(echo "$output" | sed -n 's/.*"\([^"]*\)".*/\1/p' | head -1)
+                volid=$(echo "$output" | parse_volid)
 
                 [[ -n "$volid" && "$volid" =~ ^$STORAGE_ID:vol- ]] && break
                 volid=""
@@ -1658,7 +1672,7 @@ test_performance() {
         -vmid "$vmid" \
         -filename "vm-${vmid}-disk-0" \
         -size "5G" \
-        --output-format=json 2>&1 | sed -n 's/.*"\([^"]*\)".*/\1/p' | head -1)
+        --output-format=json 2>&1 | parse_volid)
     local alloc_end=$(date +%s%3N)
     local elapsed=$((alloc_end - alloc_start))
 
@@ -1681,7 +1695,7 @@ test_performance() {
         -vmid "$vmid" \
         -filename "vm-${vmid}-disk-0" \
         -size "20G" \
-        --output-format=json 2>&1 | sed -n 's/.*"\([^"]*\)".*/\1/p' | head -1)
+        --output-format=json 2>&1 | parse_volid)
     alloc_end=$(date +%s%3N)
     elapsed=$((alloc_end - alloc_start))
 
@@ -1756,7 +1770,7 @@ test_multiple_disks() {
             -vmid "$vmid" \
             -filename "vm-${vmid}-disk-${i}" \
             -size "5G" \
-            --output-format=json 2>&1 | sed -n 's/.*"\([^"]*\)".*/\1/p' | head -1)
+            --output-format=json 2>&1 | parse_volid)
 
         if ! qm set "$vmid" -scsi${i} "$volid" >/dev/null 2>&1; then
             log_error "Failed to attach disk $i"
@@ -1866,7 +1880,7 @@ test_efi_vm_creation() {
         -vmid "$vmid" \
         -filename "vm-${vmid}-disk-0" \
         -size "1M" \
-        --output-format=json 2>&1 | sed -n 's/.*"\([^"]*\)".*/\1/p' | head -1)
+        --output-format=json 2>&1 | parse_volid)
 
     if [[ -z "$efi_volid" ]] || [[ "$efi_volid" == *"error"* ]]; then
         log_error "Failed to allocate EFI disk"
@@ -1892,7 +1906,7 @@ test_efi_vm_creation() {
         -vmid "$vmid" \
         -filename "vm-${vmid}-disk-1" \
         -size "10G" \
-        --output-format=json 2>&1 | sed -n 's/.*"\([^"]*\)".*/\1/p' | head -1)
+        --output-format=json 2>&1 | parse_volid)
 
     if ! qm set "$vmid" -scsi0 "$data_volid" >/dev/null 2>&1; then
         log_error "Failed to attach data disk"
@@ -1999,7 +2013,7 @@ test_multidisk_advanced_operations() {
             -vmid "$vmid" \
             -filename "vm-${vmid}-disk-${i}" \
             -size "5G" \
-            --output-format=json 2>&1 | sed -n 's/.*"\([^"]*\)".*/\1/p' | head -1)
+            --output-format=json 2>&1 | parse_volid)
 
         if [[ -z "$volid" ]] || [[ "$volid" == *"error"* ]]; then
             log_error "Failed to allocate disk $i"
@@ -2115,7 +2129,7 @@ test_multidisk_advanced_operations() {
             -vmid "$base_clone_vmid" \
             -filename "vm-${base_clone_vmid}-disk-${i}" \
             -size "5G" \
-            --output-format=json 2>&1 | sed -n 's/.*"\([^"]*\)".*/\1/p' | head -1)
+            --output-format=json 2>&1 | parse_volid)
 
         if ! qm set "$base_clone_vmid" -scsi${i} "$volid" >/dev/null 2>&1; then
             log_error "Failed to attach disk $i to base VM"
@@ -2217,7 +2231,7 @@ test_multidisk_advanced_operations() {
             -vmid "$vmid" \
             -filename "vm-${vmid}-disk-${i}" \
             -size "5G" \
-            --output-format=json 2>&1 | sed -n 's/.*"\([^"]*\)".*/\1/p' | head -1)
+            --output-format=json 2>&1 | parse_volid)
 
         if ! qm set "$vmid" -scsi${i} "$volid" >/dev/null 2>&1; then
             log_error "Failed to attach disk $i"
@@ -2319,7 +2333,7 @@ test_multidisk_advanced_operations() {
                 -vmid "$vmid" \
                 -filename "vm-${vmid}-disk-${i}" \
                 -size "5G" \
-                --output-format=json 2>&1 | sed -n 's/.*"\([^"]*\)".*/\1/p' | head -1)
+                --output-format=json 2>&1 | parse_volid)
 
             if ! qm set "$vmid" -scsi${i} "$volid" >/dev/null 2>&1; then
                 log_error "Failed to attach disk $i"
@@ -2460,7 +2474,7 @@ test_live_migration() {
         -vmid "$vmid" \
         -filename "vm-${vmid}-disk-0" \
         -size "5G" \
-        --output-format=json 2>&1 | sed -n 's/.*"\([^"]*\)".*/\1/p' | head -1)
+        --output-format=json 2>&1 | parse_volid)
 
     if ! qm set "$vmid" -scsi0 "$volid" >/dev/null 2>&1; then
         log_error "Failed to attach disk"
@@ -2577,7 +2591,7 @@ test_offline_migration() {
         -vmid "$vmid" \
         -filename "vm-${vmid}-disk-0" \
         -size "5G" \
-        --output-format=json 2>&1 | sed -n 's/.*"\([^"]*\)".*/\1/p' | head -1)
+        --output-format=json 2>&1 | parse_volid)
 
     if ! qm set "$vmid" -scsi0 "$volid" >/dev/null 2>&1; then
         log_error "Failed to attach disk"
@@ -2677,7 +2691,7 @@ test_online_backup() {
         -vmid "$vmid" \
         -filename "vm-${vmid}-disk-0" \
         -size "5G" \
-        --output-format=json 2>&1 | sed -n 's/.*"\([^"]*\)".*/\1/p' | head -1)
+        --output-format=json 2>&1 | parse_volid)
 
     if ! qm set "$vmid" -scsi0 "$volid" >/dev/null 2>&1; then
         log_error "Failed to attach disk"
@@ -2776,7 +2790,7 @@ test_offline_backup() {
         -vmid "$vmid" \
         -filename "vm-${vmid}-disk-0" \
         -size "5G" \
-        --output-format=json 2>&1 | sed -n 's/.*"\([^"]*\)".*/\1/p' | head -1)
+        --output-format=json 2>&1 | parse_volid)
 
     if ! qm set "$vmid" -scsi0 "$volid" >/dev/null 2>&1; then
         log_error "Failed to attach disk"
@@ -2862,7 +2876,7 @@ test_cross_node_clone_online() {
         -vmid "$base_vmid" \
         -filename "vm-${base_vmid}-disk-0" \
         -size "5G" \
-        --output-format=json 2>&1 | sed -n 's/.*"\([^"]*\)".*/\1/p' | head -1)
+        --output-format=json 2>&1 | parse_volid)
 
     if ! qm set "$base_vmid" -scsi0 "$volid" >/dev/null 2>&1; then
         log_error "Failed to attach disk"
@@ -2967,7 +2981,7 @@ test_cross_node_clone_offline() {
         -vmid "$base_vmid" \
         -filename "vm-${base_vmid}-disk-0" \
         -size "5G" \
-        --output-format=json 2>&1 | sed -n 's/.*"\([^"]*\)".*/\1/p' | head -1)
+        --output-format=json 2>&1 | parse_volid)
 
     if ! qm set "$base_vmid" -scsi0 "$volid" >/dev/null 2>&1; then
         log_error "Failed to attach disk"
@@ -3061,7 +3075,7 @@ test_rapid_create_delete_stress() {
             -filename "vm-${vmid}-disk-0" \
             -size "1G" \
             --output-format=json 2>&1) || true
-        volid=$(echo "$alloc_output" | sed -n 's/.*"\([^"]*\)".*/\1/p' | head -1)
+        volid=$(echo "$alloc_output" | parse_volid)
 
         if [[ -z "$volid" ]] || [[ "$volid" == *"error"* ]]; then
             log_error "Failed to allocate disk for VM $vmid"
@@ -3269,7 +3283,7 @@ test_storage_exhaustion() {
         -vmid "$vmid" \
         -filename "vm-${vmid}-disk-0" \
         -size "${excessive_gb}G" \
-        --output-format=json 2>&1 | sed -n 's/.*"\([^"]*\)".*/\1/p' | head -1) || alloc_exit_code=$?
+        --output-format=json 2>&1 | parse_volid) || alloc_exit_code=$?
 
     # Handle timeout (exit code 124)
     if [[ $alloc_exit_code -eq 124 ]]; then
@@ -3633,7 +3647,7 @@ test_interrupted_operations() {
         -filename "vm-${vmid}-disk-0" \
         -size "5G" \
         --output-format=json 2>&1) || alloc_exit_code=$?
-    volid=$(echo "$alloc_output" | sed -n 's/.*"\([^"]*\)".*/\1/p' | head -1)
+    volid=$(echo "$alloc_output" | parse_volid)
 
     # Check if allocation failed due to storage lock (known bug from interrupted operation)
     if echo "$alloc_output" | grep -q "cfs-lock.*error.*timeout" || \
@@ -3714,7 +3728,7 @@ test_large_disk_operations() {
         -filename "vm-${vmid}-disk-0" \
         -size "200G" \
         --output-format=json 2>&1) || true
-    volid=$(echo "$alloc_output" | sed -n 's/.*"\([^"]*\)".*/\1/p' | head -1)
+    volid=$(echo "$alloc_output" | parse_volid)
     local alloc_duration=$(($(date +%s) - alloc_start))
 
     # Check if allocation failed due to storage lock (persisting from Phase 20)
@@ -3946,7 +3960,7 @@ test_transport_mode_verification() {
         --output-format=json 2>&1) || true
     # Extract volid - successful response is just a quoted string like "storage:vol-..."
     # Error response is JSON with "code" field - check for storage ID prefix to validate
-    volid=$(echo "$alloc_output" | sed -n 's/.*"\([^"]*\)".*/\1/p' | head -1)
+    volid=$(echo "$alloc_output" | parse_volid)
 
     if [[ -z "$volid" ]] || [[ "$volid" != "${STORAGE_ID}:"* ]]; then
         log_error "Failed to allocate test disk"
@@ -4206,7 +4220,7 @@ test_snapshot_reversion() {
         -filename "vm-${vmid}-disk-0" \
         -size "8G" \
         --output-format=json 2>&1) || true
-    volid=$(echo "$alloc_output" | sed -n 's/.*"\([^"]*\)".*/\1/p' | head -1)
+    volid=$(echo "$alloc_output" | parse_volid)
 
     if [[ -z "$volid" ]] || [[ "$volid" != "${STORAGE_ID}:"* ]]; then
         log_error "Failed to allocate disk"
@@ -4539,7 +4553,7 @@ test_disk_hotswap() {
         -filename "vm-${vmid}-disk-0" \
         -size "8G" \
         --output-format=json 2>&1) || true
-    volid=$(echo "$alloc_output" | sed -n 's/.*"\([^"]*\)".*/\1/p' | head -1)
+    volid=$(echo "$alloc_output" | parse_volid)
 
     if [[ -z "$volid" ]] || [[ "$volid" != "${STORAGE_ID}:"* ]]; then
         log_error "Failed to allocate primary disk"
@@ -4587,7 +4601,7 @@ test_disk_hotswap() {
         -filename "vm-${vmid}-disk-1" \
         -size "8G" \
         --output-format=json 2>&1) || true
-    volid2=$(echo "$alloc_output2" | sed -n 's/.*"\([^"]*\)".*/\1/p' | head -1)
+    volid2=$(echo "$alloc_output2" | parse_volid)
 
     if [[ -z "$volid2" ]] || [[ "$volid2" != "${STORAGE_ID}:"* ]]; then
         log_error "Failed to allocate second disk"
@@ -5122,7 +5136,7 @@ test_nvme_stale_recovery() {
         -vmid "$vmid" \
         -filename "vm-${vmid}-disk-0" \
         -size "1G" \
-        --output-format=json 2>&1 | sed -n 's/.*"\([^"]*\)".*/\1/p' | head -1)
+        --output-format=json 2>&1 | parse_volid)
 
     if [[ -z "$volid" ]] || [[ "$volid" == *"error"* ]]; then
         log_error "Failed to allocate disk: $volid"
@@ -5294,7 +5308,7 @@ test_concurrent_alloc_free_contention() {
         -vmid "$vmid_free" \
         -filename "vm-${vmid_free}-disk-0" \
         -size "5G" \
-        --output-format=json 2>&1 | sed -n 's/.*"\([^"]*\)".*/\1/p' | head -1)
+        --output-format=json 2>&1 | parse_volid)
 
     if [[ -z "$free_volid" || "$free_volid" == *"error"* ]]; then
         log_error "Failed to allocate free-target disk"
@@ -5324,7 +5338,7 @@ test_concurrent_alloc_free_contention() {
         -vmid "$vmid_alloc" \
         -filename "vm-${vmid_alloc}-disk-0" \
         -size "5G" \
-        --output-format=json 2>&1 | sed -n 's/.*"\([^"]*\)".*/\1/p' | head -1)
+        --output-format=json 2>&1 | parse_volid)
     local baseline_end=$(date +%s%3N)
     local baseline_ms=$((baseline_end - baseline_start))
 
@@ -5359,7 +5373,7 @@ test_concurrent_alloc_free_contention() {
             -vmid "$vmid_alloc" \
             -filename "vm-${vmid_alloc}-disk-0" \
             -size "5G" \
-            --output-format=json 2>&1 | sed -n 's/.*"\([^"]*\)".*/\1/p' | head -1)
+            --output-format=json 2>&1 | parse_volid)
         local op_end=$(date +%s%3N)
         local duration_ms=$((op_end - op_start))
 
@@ -5485,7 +5499,7 @@ test_multi_disk_sequential_timing() {
             -vmid "$vmid" \
             -filename "vm-${vmid}-disk-${i}" \
             -size "5G" \
-            --output-format=json 2>&1 | sed -n 's/.*"\([^"]*\)".*/\1/p' | head -1)
+            --output-format=json 2>&1 | parse_volid)
         local disk_end=$(date +%s%3N)
         local disk_ms=$((disk_end - disk_start))
         disk_times+=("$disk_ms")
@@ -5593,7 +5607,7 @@ test_mixed_concurrent_operations() {
         -vmid "$vmid_clone_src" \
         -filename "vm-${vmid_clone_src}-disk-0" \
         -size "5G" \
-        --output-format=json 2>&1 | sed -n 's/.*"\([^"]*\)".*/\1/p' | head -1)
+        --output-format=json 2>&1 | parse_volid)
 
     if [[ -z "$src_volid" || "$src_volid" == *"error"* ]]; then
         log_error "Failed to allocate clone source disk"
@@ -5627,7 +5641,7 @@ test_mixed_concurrent_operations() {
         -vmid "$vmid_alloc" \
         -filename "vm-${vmid_alloc}-disk-0" \
         -size "5G" \
-        --output-format=json 2>&1 | sed -n 's/.*"\([^"]*\)".*/\1/p' | head -1)
+        --output-format=json 2>&1 | parse_volid)
 
     if [[ -z "$free_volid" || "$free_volid" == *"error"* ]]; then
         log_error "Failed to create free-target disk"
@@ -5655,7 +5669,7 @@ test_mixed_concurrent_operations() {
             -vmid "$vmid_alloc" \
             -filename "vm-${vmid_alloc}-disk-1" \
             -size "5G" \
-            --output-format=json 2>&1 | sed -n 's/.*"\([^"]*\)".*/\1/p' | head -1)
+            --output-format=json 2>&1 | parse_volid)
         local op_end=$(date +%s%3N)
         local duration_ms=$((op_end - op_start))
 
@@ -5810,7 +5824,7 @@ test_concurrent_clone_operations() {
             -vmid "$vid" \
             -filename "vm-${vid}-disk-0" \
             -size "5G" \
-            --output-format=json 2>&1 | sed -n 's/.*"\([^"]*\)".*/\1/p' | head -1)
+            --output-format=json 2>&1 | parse_volid)
 
         if [[ -z "$volid" || "$volid" == *"error"* ]]; then
             log_error "Failed to allocate disk for source VM $vid"
@@ -6018,7 +6032,7 @@ test_cross_node_concurrent_alloc() {
         -vmid "$vmid_local" \
         -filename "vm-${vmid_local}-disk-0" \
         -size "5G" \
-        --output-format=json 2>&1 | sed -n 's/.*"\([^"]*\)".*/\1/p' | head -1)
+        --output-format=json 2>&1 | parse_volid)
     local baseline_end=$(date +%s%3N)
     local baseline_ms=$((baseline_end - baseline_start))
 
@@ -6053,7 +6067,7 @@ test_cross_node_concurrent_alloc() {
             -vmid "$vmid_local" \
             -filename "vm-${vmid_local}-disk-0" \
             -size "5G" \
-            --output-format=json 2>&1 | sed -n 's/.*"\([^"]*\)".*/\1/p' | head -1)
+            --output-format=json 2>&1 | parse_volid)
         local op_end=$(date +%s%3N)
         local duration_ms=$((op_end - op_start))
 
@@ -6073,7 +6087,7 @@ test_cross_node_concurrent_alloc() {
             -vmid "$vmid_remote" \
             -filename "vm-${vmid_remote}-disk-0" \
             -size "5G" \
-            --output-format=json 2>&1 | sed -n 's/.*"\([^"]*\)".*/\1/p' | head -1)
+            --output-format=json 2>&1 | parse_volid)
         local op_end=$(date +%s%3N)
         local duration_ms=$((op_end - op_start))
 
@@ -6171,7 +6185,7 @@ test_concurrent_migration_alloc() {
         -vmid "$vmid_migrate" \
         -filename "vm-${vmid_migrate}-disk-0" \
         -size "5G" \
-        --output-format=json 2>&1 | sed -n 's/.*"\([^"]*\)".*/\1/p' | head -1)
+        --output-format=json 2>&1 | parse_volid)
 
     if [[ -z "$migrate_volid" || "$migrate_volid" == *"error"* ]]; then
         log_error "Failed to allocate migration disk"
@@ -6242,7 +6256,7 @@ test_concurrent_migration_alloc() {
         -vmid "$vmid_alloc" \
         -filename "vm-${vmid_alloc}-disk-0" \
         -size "5G" \
-        --output-format=json 2>&1 | sed -n 's/.*"\([^"]*\)".*/\1/p' | head -1)
+        --output-format=json 2>&1 | parse_volid)
     local baseline_alloc_end=$(date +%s%3N)
     local baseline_alloc_ms=$((baseline_alloc_end - baseline_alloc_start))
 
@@ -6293,7 +6307,7 @@ test_concurrent_migration_alloc() {
             -vmid "$vmid_alloc" \
             -filename "vm-${vmid_alloc}-disk-0" \
             -size "5G" \
-            --output-format=json 2>&1 | sed -n 's/.*"\([^"]*\)".*/\1/p' | head -1)
+            --output-format=json 2>&1 | parse_volid)
         local op_end=$(date +%s%3N)
         local duration_ms=$((op_end - op_start))
 

--- a/wiki/Changelog.md
+++ b/wiki/Changelog.md
@@ -1,5 +1,11 @@
 # TrueNAS Plugin Changelog
 
+## Version 2.1.2 (June 3, 2026)
+
+- **Fix NVMe/TCP connect failure when CPUs are offlined (issue #48)**: When CPU threads are taken offline via `/sys/devices/system/cpu/cpuN/online`, the kernel NVMe-TCP driver maps I/O queues to CPUs by index. If any CPU in the possible range is offline, connecting with more queues than `floor(possible_cpus / 2)` causes `errno: -18 (EXDEV)` because at least one queue is assigned to an offline CPU with no online fallback. `_nvme_connect` now always passes `--nr-io-queues`: the online CPU count when all CPUs are online (matching the prior kernel default), or `floor(possible / 2)` when any CPU is offline (guarantees each queue has ≥2 possible CPUs in its affinity set). New optional `tn_nr_io_queues` storage.cfg key (1–256) allows manual override for environments with TrueNAS-side queue limits.
+
+---
+
 ## Version 2.1.1 (May 29, 2026)
 
 - **Bump storage API version to 14 (GitHub issue #41)**: Updated `$TESTED_APIVER` from 13 to 14 to match `libpve-storage-perl` 9.1.3+ (Proxmox VE 9.2+), eliminating the "implementing an older storage API" warning logged at every plugin load. The APIVER 14 bump in PVE was backward compatible (added optional `get_identity()` method); no new plugin methods are required.

--- a/wiki/NVMe-Setup.md
+++ b/wiki/NVMe-Setup.md
@@ -193,6 +193,7 @@ truenasplugin: truenas-nvme
 | `tn_discovery_portal` | Yes | Primary portal IP:port | None |
 | `tn_nvme_dhchap_secret` | No | Host authentication secret | None |
 | `tn_nvme_dhchap_ctrl_secret` | No | Controller authentication secret | None |
+| `tn_nr_io_queues` | No | Pin NVMe/TCP I/O queue count per controller (1–256). Auto-detected when unset: uses online CPU count normally, or `floor(possible/2)` when any CPU is offline. Set manually if TrueNAS reports queue limit errors. | Auto-detected |
 
 **Important Notes:**
 - TrueNAS 25.10+ is required for NVMe-oF operations

--- a/wiki/README.md
+++ b/wiki/README.md
@@ -170,6 +170,6 @@ For issues not covered in documentation:
 
 ## Version Information
 
-**Version**: 2.1.1
-**Last Updated**: May 29, 2026
+**Version**: 2.1.2
+**Last Updated**: June 3, 2026
 **Compatibility**: Proxmox VE 8.x+, TrueNAS SCALE 25.10+

--- a/wiki/Troubleshooting.md
+++ b/wiki/Troubleshooting.md
@@ -26,6 +26,7 @@ Common issues and solutions for the TrueNAS Proxmox VE Storage Plugin.
   - ["nvme-cli is not installed"](#nvme-cli-is-not-installed)
   - ["Could not determine host NQN"](#could-not-determine-host-nqn)
   - ["Failed to connect to any NVMe/TCP portal"](#failed-to-connect-to-any-nvmetcp-portal)
+  - [NVMe Connect Fails After Offlining CPU Threads (EXDEV / errno -18)](#nvme-connect-fails-after-offlining-cpu-threads-exdev--errno--18)
   - [DH-CHAP Authentication Failures](#dh-chap-authentication-failures)
 - [NVMe/TCP Namespace Issues](#nvmetcp-namespace-issues)
   - ["Could not locate NVMe device for UUID"](#could-not-locate-nvme-device-for-uuid)
@@ -1092,6 +1093,44 @@ nvme list-subsys | grep -A 5 "proxmox-test"
 # Disconnect after test
 nvme disconnect -n nqn.2005-10.org.freenas.ctl:proxmox-test
 ```
+
+### NVMe Connect Fails After Offlining CPU Threads (EXDEV / errno -18)
+
+**Symptom**: NVMe/TCP connection fails after CPU threads are taken offline via `/sys/devices/system/cpu/cpuN/online` (e.g. for power saving or isolation via `isolcpus`/`cset`).
+
+**Error in dmesg**:
+```
+nvme nvmeX: Connect command failed, errno: -18
+nvme nvmeX: failed to connect queue: N ret=-18
+```
+
+**Root cause**: The kernel NVMe-TCP driver maps I/O queue N to CPU N by index. When a CPU in the middle of the possible range is offline, at least one queue gets assigned exclusively to an offline CPU, causing `EXDEV` (-18). This is a kernel driver limitation — the queue affinity is computed from the *possible* CPU bitmap, not the *online* bitmap.
+
+**Fix (v2.1.2+)**: The plugin automatically detects offline CPUs and passes `--nr-io-queues=floor(possible/2)` to `nvme connect`, which guarantees each queue maps to at least 2 possible CPUs. No manual action is required after upgrading.
+
+**Manual override** (if TrueNAS also reports queue limit errors):
+```
+# In storage.cfg — pin to a safe value for your hardware:
+tn_nr_io_queues 4
+```
+
+**Verify the fix is active**:
+```bash
+# After a connect, check how many queues were created:
+dmesg | grep -i "nvme.*creating.*I/O queues"
+# e.g.: nvme nvme3: creating 3 I/O queues.
+```
+
+**If running v2.1.1 or earlier**:
+```bash
+# Temporary workaround — reconnect with explicit queue cap:
+NQN=$(awk '/^truenasplugin: tn-nvme/{f=1} f && /tn_subsystem_nqn/{print $2; exit}' /etc/pve/storage.cfg)
+nvme disconnect -n "$NQN"
+nvme connect -t tcp -a <portal_ip> -s 4420 -n "$NQN" \
+  --nr-io-queues=$(( $(nproc --all) / 2 ))
+```
+
+---
 
 ### DH-CHAP Authentication Failures
 


### PR DESCRIPTION
## Summary

Fixes #48 — NVMe/TCP `nvme connect` fails with errno -18 (EXDEV) when CPU threads are taken offline.

### Root Cause
The kernel NVMe-TCP driver maps I/O queue N to CPU N by index. When a CPU in the possible range is offline, connecting with more queues than `floor(possible/2)` causes at least one queue to be assigned to an offline CPU with no online fallback in its affinity set.

### Changes

**TrueNASPlugin.pm:**
- Add `_read_cpu_count()` helper to parse sysfs CPU range strings (e.g. `0-3,5`) into a count
- Always pass `--nr-io-queues` to `nvme connect`:
  - All CPUs online → uses online CPU count (matches kernel default)
  - Any CPU offline → uses `floor(possible/2)`, guaranteeing each queue maps to ≥2 possible CPUs
- Add optional `tn_nr_io_queues` storage.cfg key (integer 1–256) for manual override

**dev test script:**
- Wrap volid extractions in `parse_volid()` to survive `set -euo pipefail` (grep exits 1 on no match)
- Add 30s settle wait in Phase 21 before test 2 to avoid storage lock contention

### Testing
- **Run 1** (all CPUs online): 42/42 passed, 0 failed
- **CPU offlining test**: 4/4 passed — alloc/free with 1 and 3 CPUs offline
- **Run 2** (cpu5 cycling on/off every 45s during phases 15–44): 42/42 passed, 0 failed
- Verified on 6-core Intel i5-8400T (6 possible CPUs, kernel 7.0.6-1-pve)

### Version
Bumps to v2.1.2.