### PR TITLE
install.sh: fix health check using unprefixed scfg keys

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -6603,11 +6603,11 @@ tn_api_call() {
 
         # Build minimal scfg for API call
         my $scfg = {
-            api_host => $host,
-            api_key => $api_key,
-            api_insecure => 1,
+            tn_api_host => $host,
+            tn_api_key => $api_key,
+            tn_api_insecure => 1,
         };
-        $scfg->{api_port} = int($api_port) if $api_port;
+        $scfg->{tn_api_port} = int($api_port) if $api_port;
 
         # Decode params
         my $params = eval { decode_json($params_json) } // [];
@@ -6665,11 +6665,11 @@ tn_api_call_write() {
 
         # Build minimal scfg for API call
         my $scfg = {
-            api_host => $host,
-            api_key => $api_key,
-            api_insecure => 1,
+            tn_api_host => $host,
+            tn_api_key => $api_key,
+            tn_api_insecure => 1,
         };
-        $scfg->{api_port} = int($api_port) if $api_port;
+        $scfg->{tn_api_port} = int($api_port) if $api_port;
 
         # Decode params - fail fast if JSON is invalid
         my $params = eval { decode_json($params_json) };
@@ -8729,12 +8729,12 @@ execute_provisioning() {
             use PVE::Storage::Custom::TrueNASPlugin ();
 
             my $scfg = {
-                api_host => $ARGV[0],
-                api_key => $ARGV[1],
-                api_insecure => 1,
-                dataset => $ARGV[2],
-                target_iqn => $ARGV[3],
-                discovery_portal => $ARGV[4],
+                tn_api_host => $ARGV[0],
+                tn_api_key => $ARGV[1],
+                tn_api_insecure => 1,
+                tn_dataset => $ARGV[2],
+                tn_target_iqn => $ARGV[3],
+                tn_discovery_portal => $ARGV[4],
             };
 
             eval { PVE::Storage::Custom::TrueNASPlugin::_ensure_target_visible($scfg) };

--- a/install.sh
+++ b/install.sh
@@ -3812,6 +3812,10 @@ menu_cleanup_orphans() {
     transport_mode=$(get_storage_config_value "$storage_name" "tn_transport_mode" || true)
     TN_API_PORT="$(get_storage_config_value "$storage_name" "tn_api_port" 2>/dev/null || true)"
     TN_API_PORT="${TN_API_PORT:-443}"
+    # Honor the storage's configured tn_api_insecure (blank/unset means
+    # verify certs, matching the plugin's own default) for subsequent
+    # tn_api_call/tn_api_call_write invocations in this function.
+    TN_API_INSECURE="${api_insecure:-0}"
 
     # Default to iscsi if not specified
     [[ -z "$transport_mode" ]] && transport_mode="iscsi"
@@ -4367,6 +4371,11 @@ detect_orphaned_resources() {
     local dataset="$5"
     local api_insecure="$6"
 
+    # Honor the storage's configured tn_api_insecure (blank/unset means
+    # verify certs, matching the plugin's own default) for the
+    # tn_api_call invocations below.
+    TN_API_INSECURE="${api_insecure:-0}"
+
     local orphan_count=0
 
     if [[ "$transport_mode" == "iscsi" ]]; then
@@ -4728,6 +4737,11 @@ run_health_check() {
     api_port=$(get_storage_config_value "$storage_name" "tn_api_port")
     api_port=${api_port:-443}
     TN_API_PORT="$api_port"
+    # Honor the storage's configured tn_api_insecure (blank/unset means
+    # verify certs, matching the plugin's own default) for the
+    # tn_api_call invocations below.
+    TN_API_INSECURE="$(get_storage_config_value "$storage_name" "tn_api_insecure")"
+    TN_API_INSECURE="${TN_API_INSECURE:-0}"
 
     if [[ -n "$api_host" ]]; then
         printf "%-30s " "TrueNAS API:"
@@ -5113,6 +5127,9 @@ run_health_check() {
         api_insecure_nvme=$(get_storage_config_value "$storage_name" "tn_api_insecure")
         TN_API_PORT="$(get_storage_config_value "$storage_name" "tn_api_port" 2>/dev/null || true)"
         TN_API_PORT="${TN_API_PORT:-443}"
+        # Honor the storage's configured tn_api_insecure (blank/unset
+        # means verify certs, matching the plugin's own default).
+        TN_API_INSECURE="${api_insecure_nvme:-0}"
 
         if [[ -n "$api_host_nvme" ]] && [[ -n "$api_key_nvme" ]] && [[ -n "$dataset" ]]; then
             printf "%-30s " "Orphaned resources:"
@@ -6599,13 +6616,18 @@ tn_api_call() {
         use PVE::Storage::Custom::TrueNASPlugin ();
         use JSON::PP;
 
-        my ($host, $api_key, $method, $params_json, $api_port) = @ARGV;
+        my ($host, $api_key, $method, $params_json, $api_port, $api_insecure) = @ARGV;
 
         # Build minimal scfg for API call
         my $scfg = {
             tn_api_host => $host,
             tn_api_key => $api_key,
-            tn_api_insecure => 1,
+            # Default to insecure (skip TLS verification) for backward
+            # compatibility with self-signed TrueNAS certs, but honor an
+            # explicit "0" (e.g. from the configured storage.cfg entry or
+            # TN_API_INSECURE env var) so users with valid certs can opt
+            # into verification.
+            tn_api_insecure => (defined $api_insecure && $api_insecure eq '0') ? 0 : 1,
         };
         $scfg->{tn_api_port} = int($api_port) if $api_port;
 
@@ -6624,7 +6646,7 @@ tn_api_call() {
 
         # Output result as JSON
         print encode_json($result) if defined $result;
-    ' "$host" "$api_key" "$method" "$params" "${TN_API_PORT:-}" 2>&1)
+    ' "$host" "$api_key" "$method" "$params" "${TN_API_PORT:-}" "${TN_API_INSECURE:-1}" 2>&1)
     exit_code=$?
 
     if [[ $exit_code -ne 0 ]]; then
@@ -6661,13 +6683,18 @@ tn_api_call_write() {
         use PVE::Storage::Custom::TrueNASPlugin ();
         use JSON::PP;
 
-        my ($host, $api_key, $method, $params_json, $api_port) = @ARGV;
+        my ($host, $api_key, $method, $params_json, $api_port, $api_insecure) = @ARGV;
 
         # Build minimal scfg for API call
         my $scfg = {
             tn_api_host => $host,
             tn_api_key => $api_key,
-            tn_api_insecure => 1,
+            # Default to insecure (skip TLS verification) for backward
+            # compatibility with self-signed TrueNAS certs, but honor an
+            # explicit "0" (e.g. from the configured storage.cfg entry or
+            # TN_API_INSECURE env var) so users with valid certs can opt
+            # into verification.
+            tn_api_insecure => (defined $api_insecure && $api_insecure eq '0') ? 0 : 1,
         };
         $scfg->{tn_api_port} = int($api_port) if $api_port;
 
@@ -6691,7 +6718,7 @@ tn_api_call_write() {
 
         # Output result as JSON
         print encode_json($result) if defined $result;
-    ' "$host" "$api_key" "$method" "$params" "${TN_API_PORT:-}" 2>&1)
+    ' "$host" "$api_key" "$method" "$params" "${TN_API_PORT:-}" "${TN_API_INSECURE:-1}" 2>&1)
     exit_code=$?
 
     if [[ $exit_code -ne 0 ]]; then
@@ -8731,7 +8758,12 @@ execute_provisioning() {
             my $scfg = {
                 tn_api_host => $ARGV[0],
                 tn_api_key => $ARGV[1],
-                tn_api_insecure => 1,
+                # Default to insecure (skip TLS verification) since the
+                # setup wizard does not yet collect a certificate-trust
+                # choice and new storage.cfg entries default to
+                # tn_api_insecure=1; honor an explicit "0" (e.g. from
+                # TN_API_INSECURE env var) so it can be overridden.
+                tn_api_insecure => ($ARGV[5] // "1") eq "0" ? 0 : 1,
                 tn_dataset => $ARGV[2],
                 tn_target_iqn => $ARGV[3],
                 tn_discovery_portal => $ARGV[4],
@@ -8743,7 +8775,7 @@ execute_provisioning() {
                 exit 1;
             }
             print "OK";
-        ' "$host" "$api_key" "$PROVISIONED_DATASET" "$PROVISIONED_TARGET_IQN" "${PROV_PORTAL_IP}:${PROV_PORTAL_PORT}" 2>&1)
+        ' "$host" "$api_key" "$PROVISIONED_DATASET" "$PROVISIONED_TARGET_IQN" "${PROV_PORTAL_IP}:${PROV_PORTAL_PORT}" "${TN_API_INSECURE:-1}" 2>&1)
         local weight_exit=$?
         stop_spinner
 


### PR DESCRIPTION
## Summary

Fixes three inline Perl snippets in `install.sh` (`tn_api_call`, `tn_api_call_write`, and the weight-volume provisioning block in `execute_provisioning`) that built a "minimal scfg" hash using legacy unprefixed keys: `api_host`, `api_key`, `api_insecure`, `dataset`, `target_iqn`, `discovery_portal`.

Since v2.1.0, `TrueNASPlugin.pm` internals (`_api_call`, `_broker_call`, `_ensure_target_visible`, etc.) only read `tn_`-prefixed keys (`tn_api_host`, `tn_api_key`, ...). This mismatch meant the installer's health check and plugin-function-test always sent an incomplete scfg to the broker, producing `broker: scfg missing api_host/api_key` regardless of whether the actual `storage.cfg` was valid.

The fix renames the keys in all three locations to `tn_api_host`, `tn_api_key`, `tn_api_insecure`, `tn_api_port`, `tn_dataset`, `tn_target_iqn`, `tn_discovery_portal`, matching the convention already correctly used elsewhere in the codebase (`tools/nvme-recovery.sh`, `tools/dev-truenas-plugin-full-function-test.sh`).

This is a scoped, install.sh-only change — no changes to `TrueNASPlugin.pm`.

## Follow-up: TLS verification fix (addresses Copilot review)

Copilot's automated review correctly flagged that once `tn_api_insecure` is actually wired up to the plugin (this PR''s whole point), the previously-inert hardcoded `tn_api_insecure => 1` in these three snippets now has a real effect: it unconditionally disables TLS certificate verification for every installer API call, even for users with valid certificates who'd want verification enabled.

Fixed in a follow-up commit by threading a `TN_API_INSECURE` global through `tn_api_call`/`tn_api_call_write`/the weight-volume helper (mirroring the existing `TN_API_PORT` convention). Code paths that already read the storage's configured `tn_api_insecure` (health check, orphan detection) now propagate that real value instead of silently forcing `1`. Contexts without a configured storage.cfg yet (the initial setup wizard) keep defaulting to insecure=1, consistent with the self-signed-cert assumption already baked into `generate_storage_config` (new storage.cfg entries are always written with `tn_api_insecure 1` today).

## Relation to #62

This helps with #62 ("API authentication error in health check with valid api key") — the installer's health check was hitting exactly this bug (`scfg missing api_host/api_key` in the broker log), which is unrelated to whether the API key itself is valid.

**Note for maintainers**: in my own case (a similar but not identical report), this install.sh fix corrected the health check's scfg construction, but the actual root cause of my API authentication failure turned out to be an outdated plugin version — updating `TrueNASPlugin.pm` resolved the "Authentication failed" health check result. So this PR fixes a real, reproducible bug in the health-check tooling, but may not be the *sole* fix for every case described in #62; it's worth confirming with the original reporter whether it fully resolves their scenario too.

## Testing

- `bash -n install.sh` passes (syntax check)
- Confirmed via `TrueNASPlugin.pm` source (`_api_call`, `_ensure_target_visible`) that these are exactly the keys the plugin reads from `$scfg`