### PR TITLE
TrueNASPlugin.pm: fix stale internal VERSION string (drifted since 2.1.5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,6 @@ This project is provided as-is for use with Proxmox VE and TrueNAS SCALE.
 
 ---
 
-**Version**: 2.1.5
-**Last Updated**: June 16, 2026
+**Version**: 2.1.17
+**Last Updated**: July 1, 2026
 **Compatibility**: Proxmox VE 8.x+, TrueNAS SCALE 25.10+

--- a/TrueNASPlugin.pm
+++ b/TrueNASPlugin.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 
 # Plugin Version
-our $VERSION = '2.1.5';
+our $VERSION = '2.1.17';
 # Highest Proxmox storage API version this plugin is validated against.
 our $TESTED_APIVER = 14;
 use JSON::PP qw(encode_json decode_json);

--- a/wiki/README.md
+++ b/wiki/README.md
@@ -170,6 +170,6 @@ For issues not covered in documentation:
 
 ## Version Information
 
-**Version**: 2.1.5
-**Last Updated**: June 16, 2026
+**Version**: 2.1.17
+**Last Updated**: July 1, 2026
 **Compatibility**: Proxmox VE 8.x+, TrueNAS SCALE 25.10+


### PR DESCRIPTION
## Summary

`our $VERSION` in `TrueNASPlugin.pm` (line 7) was last bumped to `2.1.5` in commit fe06ea1 ("fix: classify WS framing errors as connection errors for reconnect") and was never updated again in any subsequent release, even though `debian/changelog` and git release tags advanced all the way through `2.1.17`.

```
$ git log --oneline -L 7,7:TrueNASPlugin.pm
fe06ea1 fix: classify WS framing errors as connection errors for reconnect
-our $VERSION = '"'"'2.1.4'"'"';
+our $VERSION = '"'"'2.1.5'"'"';
```

## Impact

The installer's update flow (`perform_installation`) correctly fetches, downloads, and installs the actual file content for the latest release tag (e.g. `v2.1.17-deb1`). However, since that file's own `our $VERSION` line was frozen at `2.1.5`, anything that reads the version back out of the installed file reports the wrong number:

- `install.sh`'s health check ("Plugin file: v2.1.5")
- The main menu banner ("TrueNAS Plugin vX.Y.Z - Installed")

This makes it look like updates are silently capping at v2.1.5 and not actually applying, when in reality the new code **is** installed and running — only the self-reported version string is stale. This caused confusion in my own troubleshooting of #62 (I initially assumed the update mechanism was broken/capped, until I found the file's embedded VERSION hadn't moved in 12 releases).

## Fix

- Bump `our $VERSION` to `2.1.17` to match the current release.
- Update the matching stale `**Version**: 2.1.5` footers in `README.md` and `wiki/README.md`.

This PR is scoped to these three files only. (A separate, related `install.sh` fix for the health check's scfg key names lives in #63 — kept as its own PR so each change can be reviewed/merged independently.)

## Suggestion for maintainers

Consider adding a release-process check (e.g. a CI step or a `tools/` helper) that fails the release if `our $VERSION` in `TrueNASPlugin.pm` doesn't match the `debian/changelog` version being tagged, to prevent this drift from recurring.