### PR TITLE
Fix stale wiki documentation: renamed functions, removed API namespace, dead config keys

### DIFF
--- a/wiki/API-Reference.md
+++ b/wiki/API-Reference.md
@@ -193,7 +193,7 @@ WebSocket: pool.dataset.delete
 
 #### Create Snapshot
 ```
-WebSocket: zfs.snapshot.create
+WebSocket: pool.snapshot.create
 ```
 
 **Parameters**:
@@ -216,7 +216,7 @@ WebSocket: zfs.snapshot.create
 
 #### List Snapshots
 ```
-WebSocket: zfs.snapshot.query
+WebSocket: pool.snapshot.query
 ```
 
 **Parameters**:
@@ -228,12 +228,12 @@ WebSocket: zfs.snapshot.query
 
 #### Delete Snapshot
 ```
-WebSocket: zfs.snapshot.delete
+WebSocket: pool.snapshot.delete
 ```
 
 #### Rollback Snapshot
 ```
-WebSocket: zfs.snapshot.rollback
+WebSocket: pool.snapshot.rollback
 ```
 
 ### iSCSI Operations
@@ -584,31 +584,27 @@ WebSocket responses include rate limit information in error messages when limits
 
 ## Connection Management
 
-### WebSocket Connection Caching
+The plugin has two connection modes. Both are used transparently by `_api_call()` — reads and writes alike; `_api_call_mutate()` is a thin wrapper around the same function. See [Advanced-Features.md](Advanced-Features.md#connection-routing-broker-vs-direct-mode) for the concurrency rationale.
 
-**Cache Lifetime**: 60 seconds
+### Broker Mode (preferred)
+
+When `/run/truenas-plugin/broker.sock` is present, every call from every plugin process on the node is forwarded to the `truenas-plugin-broker` daemon over that Unix socket — one newline-delimited JSON-RPC request per connection, closed immediately after the response. The broker holds a single persistent, authenticated WebSocket per `(host, api_key)` pair upstream to TrueNAS, so plugin processes never re-authenticate individually. Round-trip timeout is tunable via `tn_broker_timeout` (default 30s). See [Broker-Tests.md](Broker-Tests.md).
+
+### Direct Mode (fallback)
 
 **Behavior**:
-- First API call creates WebSocket connection
-- Subsequent calls reuse connection (within 60s)
-- Connection auto-closed after 60s idle
-- Auto-reconnect on connection loss
+- First API call for a given `(host, api_key)` pair opens a WebSocket connection and caches it in-process (keyed on `host:api_key`)
+- Subsequent calls in the same process reuse that connection indefinitely — there is no idle timeout that proactively closes it
+- On a failed call, the dead connection is discarded and a fresh one opened on the next call
+- Connections are never shared across processes; each PVE daemon/worker keeps its own cache
 
 **Benefits**:
 - Reduced TLS handshake overhead
 - Lower API call count (no repeated auth)
-- Better performance (~20-30ms savings per call)
-
-### Connection Pooling
-
-Multiple simultaneous operations share connections:
-- One connection per `(host, port, scheme)` tuple
-- Thread-safe connection management
-- Automatic cleanup of stale connections
 
 ### Fork Safety
 
-Persistent WebSocket connections are protected against fork-related issues (common with pvestatd workers):
+Direct-mode connections are protected against fork-related issues (common with pvestatd workers):
 
 - **PID Tracking**: Connections track the process that created them
 - **Fork Detection**: Child processes detect inherited connections via PID mismatch
@@ -715,8 +711,8 @@ API keys stored in `/etc/pve/storage.cfg`:
 
 ### Snapshot Creation
 
-1. `zfs.snapshot.create` - Create snapshot
-2. `zfs.snapshot.query` - Verify created
+1. `pool.snapshot.create` - Create snapshot
+2. `pool.snapshot.query` - Verify created
 
 ### Status Check
 

--- a/wiki/Advanced-Features.md
+++ b/wiki/Advanced-Features.md
@@ -772,12 +772,14 @@ chmod +x /usr/local/bin/monitor-multipath.sh
 ```
 
 #### See Also
-- [Configuration Reference - use_multipath](Configuration.md#use_multipath)
-- [Configuration Reference - portals](Configuration.md#portals)
+- [Configuration Reference - tn_use_multipath](Configuration.md#tn_use_multipath)
+- [Configuration Reference - tn_portals](Configuration.md#tn_portals)
 - [Known Limitations - Multipath Read Performance](Known-Limitations.md#multipath-read-performance-limitation)
 - [Troubleshooting - Slow Multipath Read Performance](Troubleshooting.md#slow-multipath-read-performance)
 
 ### vmstate Storage Location
+
+> ⚠️ **`tn_vmstate_storage` is not currently implemented** — see [Configuration Reference](Configuration.md#tn_vmstate_storage). vmstate placement for live snapshots is handled automatically by Proxmox core, not by this plugin.
 
 Choose where to store VM memory state during live snapshots:
 
@@ -840,28 +842,19 @@ Jitter: Random 0-20% added to prevent thundering herd
 
 ### Concurrent Operations and Storage Lock Timeout
 
-The plugin is optimized to handle parallel disk allocations and bulk storage operations through a combination of ephemeral WebSocket connections and extended lock timeouts.
+The plugin is optimized to handle parallel disk allocations and bulk storage operations through a combination of connection routing (broker or persistent WebSocket) and extended lock timeouts.
 
-#### Ephemeral WebSocket Connections for Write Operations
+#### Connection Routing: Broker vs. Direct Mode
 
-All write operations (create, update, delete) use one-time WebSocket connections that are created, used, and immediately closed. This prevents response interleaving issues when multiple concurrent processes perform operations simultaneously.
+All API calls — reads and writes alike — go through `_api_call()` (writes route through `_api_call_mutate()`, a thin wrapper around the same function). There is no longer a separate ephemeral-connection path for write operations; both share the same routing logic below.
 
-**How it Works**:
-1. For each write operation, a new WebSocket connection is created via `_ws_open_ephemeral()`
-2. The operation is executed on this isolated connection
-3. Connection is immediately closed via `_ws_close_ephemeral()` with RFC 6455 compliant close frame
-4. Read operations continue using cached persistent connections for efficiency
+**Broker mode (preferred)**: when `/run/truenas-plugin/broker.sock` is present, every call from every plugin process on the node is forwarded to the `truenas-plugin-broker` daemon over that Unix socket — one newline-delimited JSON-RPC request per connection, closed immediately after the response. The broker itself holds a single persistent, authenticated WebSocket per `(host, api_key)` pair upstream to TrueNAS, so individual plugin processes never re-authenticate. This eliminates both per-process re-auth (see [D2](D2-per-process-reauth.md)) and the response-interleaving risk that per-write ephemeral connections used to guard against. Round-trip timeout is tunable via `tn_broker_timeout` (default 30s). See [Broker-Tests.md](Broker-Tests.md) for the full defect analysis.
 
-**Affected Write Operations**:
-- Dataset operations (create, delete, update, clone)
-- iSCSI extent and target-extent creation/deletion
-- Snapshot operations (create, delete, rollback)
-- NVMe namespace operations
-- Bulk operations via core.bulk API
+**Direct mode (fallback)**: when no broker socket is present, the plugin manages its own `%_ws_connections` cache, keyed by `host:api_key`, shared by both reads and writes.
 
-**Fork Safety for Persistent Connections**:
+**Fork Safety for Direct-Mode Connections**:
 
-Read operations use persistent (cached) connections for efficiency. These are protected against fork-related crashes through the NullDestructor pattern:
+Cached direct-mode connections are protected against fork-related crashes through the NullDestructor pattern:
 
 - Child processes (e.g., pvestatd workers) detect inherited connections via PID mismatch
 - Inherited sockets are reblessed into a `NullDestructor` class with empty `DESTROY` method
@@ -1198,6 +1191,7 @@ qm start 100  # VM resumes exactly where it was
 tn_enable_live_snapshots 1
 tn_vmstate_storage local  # Or 'shared'
 ```
+> ⚠️ `tn_enable_live_snapshots` and `tn_vmstate_storage` are not currently implemented (see [Configuration Reference](Configuration.md#tn_enable_live_snapshots)) — live snapshots work regardless of these settings, since Proxmox core handles vmstate placement automatically.
 
 **Use Cases**:
 - Development snapshots - save exact working state
@@ -1211,6 +1205,7 @@ Proxmox 9.x+ supports volume-based snapshot chains:
 ```ini
 tn_snapshot_volume_chains 1
 ```
+> ⚠️ `tn_snapshot_volume_chains` is not currently implemented (see [Configuration Reference](Configuration.md#tn_snapshot_volume_chains)) — this setting has no effect on plugin behavior.
 
 **Benefits**:
 - Better snapshot management
@@ -1581,9 +1576,9 @@ truenasplugin: ipv6-storage
 ```
 
 **Key Settings**:
-- `prefer_ipv4 0` - Disable IPv4 preference
-- `ipv6_by_path 1` - Normalize IPv6 in device paths
-- `use_by_path 1` - Required for IPv6
+- `tn_prefer_ipv4 0` - Disable IPv4 preference
+- `tn_ipv6_by_path 1` - Normalize IPv6 in device paths (⚠️ not currently implemented — see [Configuration Reference](Configuration.md#tn_ipv6_by_path))
+- `tn_use_by_path 1` - Required for IPv6
 
 ### Development Configuration
 

--- a/wiki/Advanced-Features.md
+++ b/wiki/Advanced-Features.md
@@ -1186,12 +1186,13 @@ qm rollback 100 backup-live
 qm start 100  # VM resumes exactly where it was
 ```
 
+> ⚠️ `tn_enable_live_snapshots` and `tn_vmstate_storage` are not currently implemented (see [Configuration Reference](Configuration.md#tn_enable_live_snapshots)) — live snapshots work regardless of these settings, since Proxmox core handles vmstate placement automatically.
+
 **Configuration**:
 ```ini
 tn_enable_live_snapshots 1
 tn_vmstate_storage local  # Or 'shared'
 ```
-> ⚠️ `tn_enable_live_snapshots` and `tn_vmstate_storage` are not currently implemented (see [Configuration Reference](Configuration.md#tn_enable_live_snapshots)) — live snapshots work regardless of these settings, since Proxmox core handles vmstate placement automatically.
 
 **Use Cases**:
 - Development snapshots - save exact working state
@@ -1202,10 +1203,11 @@ tn_vmstate_storage local  # Or 'shared'
 
 Proxmox 9.x+ supports volume-based snapshot chains:
 
+> ⚠️ `tn_snapshot_volume_chains` is not currently implemented (see [Configuration Reference](Configuration.md#tn_snapshot_volume_chains)) — this setting has no effect on plugin behavior.
+
 ```ini
 tn_snapshot_volume_chains 1
 ```
-> ⚠️ `tn_snapshot_volume_chains` is not currently implemented (see [Configuration Reference](Configuration.md#tn_snapshot_volume_chains)) — this setting has no effect on plugin behavior.
 
 **Benefits**:
 - Better snapshot management

--- a/wiki/Configuration.md
+++ b/wiki/Configuration.md
@@ -6,56 +6,62 @@ Complete reference for all TrueNAS Proxmox VE Storage Plugin configuration param
 
 - [Configuration File](#configuration-file)
 - [Required Parameters](#required-parameters)
-  - [api_host](#api_host)
-  - [api_key](#api_key)
-  - [target_iqn](#target_iqn)
-  - [dataset](#dataset)
-  - [discovery_portal](#discovery_portal)
+  - [tn_api_host](#tn_api_host)
+  - [tn_api_key](#tn_api_key)
+  - [tn_target_iqn](#tn_target_iqn)
+  - [tn_dataset](#tn_dataset)
+  - [tn_discovery_portal](#tn_discovery_portal)
 - [Content Type](#content-type)
   - [content](#content)
   - [shared](#shared)
   - [nodes](#nodes)
- - [API Configuration](#api-configuration)
-  - [api_scheme](#api_scheme)
-  - [api_port](#api_port)
-  - [api_insecure](#api_insecure)
-  - [api_retry_max](#api_retry_max)
-  - [api_retry_delay](#api_retry_delay)
-  - [storage_lock_timeout](#storage_lock_timeout)
+- [API Configuration](#api-configuration)
+  - [tn_api_scheme](#tn_api_scheme)
+  - [tn_api_port](#tn_api_port)
+  - [tn_api_insecure](#tn_api_insecure)
+  - [tn_api_retry_max](#tn_api_retry_max)
+  - [tn_api_retry_delay](#tn_api_retry_delay)
+  - [tn_storage_lock_timeout](#tn_storage_lock_timeout)
 - [Network Configuration](#network-configuration)
-  - [prefer_ipv4](#prefer_ipv4)
-  - [portals](#portals)
-  - [use_multipath](#use_multipath)
-  - [use_by_path](#use_by_path)
-  - [ipv6_by_path](#ipv6_by_path)
+  - [tn_prefer_ipv4](#tn_prefer_ipv4)
+  - [tn_portals](#tn_portals)
+  - [tn_use_multipath](#tn_use_multipath)
+  - [tn_use_by_path](#tn_use_by_path)
+  - [tn_ipv6_by_path](#tn_ipv6_by_path) ⚠️ not implemented
 - [Transport Mode Selection](#transport-mode-selection)
-  - [transport_mode](#transport_mode)
+  - [tn_transport_mode](#tn_transport_mode)
 - [NVMe/TCP Configuration](#nvmetcp-configuration)
-  - [subsystem_nqn](#subsystem_nqn)
-  - [hostnqn](#hostnqn)
-  - [nvme_dhchap_secret](#nvme_dhchap_secret)
-  - [nvme_dhchap_ctrl_secret](#nvme_dhchap_ctrl_secret)
+  - [tn_subsystem_nqn](#tn_subsystem_nqn)
+  - [tn_hostnqn](#tn_hostnqn)
+  - [tn_nvme_dhchap_secret](#tn_nvme_dhchap_secret)
+  - [tn_nvme_dhchap_ctrl_secret](#tn_nvme_dhchap_ctrl_secret)
+  - [tn_nr_io_queues](#tn_nr_io_queues)
 - [iSCSI Behavior](#iscsi-behavior)
-  - [force_delete_on_inuse](#force_delete_on_inuse)
-  - [logout_on_free](#logout_on_free)
+  - [tn_force_delete_on_inuse](#tn_force_delete_on_inuse)
+  - [tn_logout_on_free](#tn_logout_on_free)
 - [ZFS Volume Options](#zfs-volume-options)
-  - [zvol_blocksize](#zvol_blocksize)
+  - [tn_zvol_blocksize](#tn_zvol_blocksize)
   - [tn_sparse](#tn_sparse)
+  - [tn_compression](#tn_compression)
 - [Snapshot Configuration](#snapshot-configuration)
-  - [vmstate_storage](#vmstate_storage)
-  - [enable_live_snapshots](#enable_live_snapshots)
-  - [snapshot_volume_chains](#snapshot_volume_chains)
+  - [tn_vmstate_storage](#tn_vmstate_storage) ⚠️ not implemented
+  - [tn_enable_live_snapshots](#tn_enable_live_snapshots) ⚠️ not implemented
+  - [tn_snapshot_volume_chains](#tn_snapshot_volume_chains) ⚠️ not implemented
 - [Performance Options](#performance-options)
-  - [enable_bulk_operations](#enable_bulk_operations)
+  - [tn_enable_bulk_operations](#tn_enable_bulk_operations)
+  - [tn_device_ready_retries](#tn_device_ready_retries)
 - [Security Options](#security-options)
-  - [chap_user](#chap_user)
-  - [chap_password](#chap_password)
+  - [tn_chap_user](#tn_chap_user)
+  - [tn_chap_password](#tn_chap_password)
 - [Diagnostics](#diagnostics)
-  - [debug](#debug)
+  - [tn_debug](#tn_debug)
 - [Configuration Examples](#configuration-examples)
-  - [Basic Single-Node Configuration](#basic-single-node-configuration)
+  - [Basic Single-Node Configuration (iSCSI)](#basic-single-node-configuration-iscsi)
+  - [Basic NVMe/TCP Configuration](#basic-nvmetcp-configuration)
   - [Production Cluster Configuration](#production-cluster-configuration)
   - [High Availability Configuration](#high-availability-configuration)
+  - [NVMe/TCP with DH-CHAP Authentication](#nvmetcp-with-dh-chap-authentication)
+  - [NVMe/TCP Multipath Configuration](#nvmetcp-multipath-configuration)
   - [IPv6 Configuration](#ipv6-configuration)
   - [Development/Testing Configuration](#developmenttesting-configuration)
   - [Enterprise Production Configuration (All Features)](#enterprise-production-configuration-all-features)
@@ -308,6 +314,7 @@ tn_use_by_path 0
 ```
 
 ### `tn_ipv6_by_path`
+**Status**: ⚠️ Not currently implemented — accepted in `storage.cfg` but has no effect on plugin behavior
 **Description**: Normalize IPv6 addresses in by-path device names
 **Type**: Boolean (0 or 1)
 **Default**: `0`
@@ -481,6 +488,18 @@ tn_nvme_dhchap_ctrl_secret DHHC-1:01:6Fk0dLGH1uPYPVKlyTNOWf4dk8FNOs9abL1p4cT0Qq2
 - **Unidirectional** (host secret only): Proxmox proves identity to TrueNAS
 - **Bidirectional** (host + controller secrets): Both sides prove identity (recommended)
 
+### `tn_nr_io_queues`
+**Description**: Number of NVMe/TCP I/O queues per controller
+**Type**: Integer
+**Valid Range**: 1-256
+**Default**: None (auto-detected)
+
+When unset, the plugin auto-detects a queue count: the online CPU count when all CPUs are online, or half of the possible CPU count when any CPU is offlined (avoids kernel queue-to-CPU mapping failures on gapped CPU topologies, e.g. `EXDEV` errors). Set explicitly to override auto-detection.
+
+```ini
+tn_nr_io_queues 8
+```
+
 ## iSCSI Behavior
 
 ### `tn_force_delete_on_inuse`
@@ -531,9 +550,24 @@ Sparse volumes only consume space as data is written, enabling overprovisioning.
 tn_sparse 1
 ```
 
+### `tn_compression`
+**Description**: ZFS compression algorithm for new volumes
+**Type**: String
+**Valid Values**: `OFF`, `LZ4`, `GZIP`, `GZIP-1`, `GZIP-9`, `ZSTD`, `ZSTD-1`, `ZSTD-3`, `ZSTD-5`, `ZSTD-7`, `ZSTD-9`, `ZLE`, `LZJB`
+**Default**: None (inherits from the parent dataset)
+
+Applied at zvol creation time. Existing volumes are unaffected by later changes to this setting.
+
+```ini
+tn_compression ZSTD
+```
+
 ## Snapshot Configuration
 
+> ⚠️ **The three options below (`tn_vmstate_storage`, `tn_enable_live_snapshots`, `tn_snapshot_volume_chains`) are not currently implemented.** They are declared in the plugin's `storage.cfg` schema (so setting them is accepted without error) but are never read anywhere in the plugin — they have no effect on runtime behavior. Live VM snapshots with vmstate are handled automatically by Proxmox core, not gated by these flags. Documented here for when/if the feature is implemented.
+
 ### `tn_vmstate_storage`
+**Status**: ⚠️ Not currently implemented — accepted in `storage.cfg` but has no effect on plugin behavior
 **Description**: Storage location for VM state (RAM) during live snapshots
 **Type**: String
 **Valid Values**: `local`, `shared`
@@ -547,6 +581,7 @@ tn_vmstate_storage local
 ```
 
 ### `tn_enable_live_snapshots`
+**Status**: ⚠️ Not currently implemented — accepted in `storage.cfg` but has no effect on plugin behavior
 **Description**: Enable live VM snapshots with vmstate
 **Type**: Boolean (0 or 1)
 **Default**: `1`
@@ -558,6 +593,7 @@ tn_enable_live_snapshots 1
 ```
 
 ### `tn_snapshot_volume_chains`
+**Status**: ⚠️ Not currently implemented — accepted in `storage.cfg` but has no effect on plugin behavior
 **Description**: Use volume snapshot chains (Proxmox 9+)
 **Type**: Boolean (0 or 1)
 **Default**: `1`
@@ -579,6 +615,18 @@ Batch multiple API calls into single bulk request for better performance.
 
 ```ini
 tn_enable_bulk_operations 1
+```
+
+### `tn_device_ready_retries`
+**Description**: Number of 100ms retries waiting for a block device to appear after connect
+**Type**: Integer
+**Valid Range**: 0-600
+**Default**: `200` (up to ~20s)
+
+Increase on slower storage backends or high-latency networks where the block device takes longer to appear after an iSCSI login or NVMe connect.
+
+```ini
+tn_device_ready_retries 200
 ```
 
 ## Security Options

--- a/wiki/D2-per-process-reauth.md
+++ b/wiki/D2-per-process-reauth.md
@@ -1,5 +1,7 @@
 # D2 — per-process re-authentication
 
+> **Status: fixed.** The session broker described in option 1 below (`## What a real D2 fix looks like`) has since been merged directly into `TrueNASPlugin.pm` (`_broker_open_socket`/`_broker_try_open`/`_broker_rpc`, commit `b9c47d3`), not just the standalone `broker-service` branch this doc originally referenced. When `/run/truenas-plugin/broker.sock` is present, `_ws_get_persistent` routes through it automatically. The rest of this document is kept as-written for the problem analysis and rejected alternatives (options 2 and 3); treat any present-tense description of the broker as "implemented in mainline," not "proposed."
+
 ## Symptom
 
 Every short-lived Proxmox process that talks to TrueNAS does its own

--- a/wiki/Installation.md
+++ b/wiki/Installation.md
@@ -1057,15 +1057,15 @@ telnet YOUR_TRUENAS_IP 3260
 # Valid: "tank/my-storage" or "tank/mystorage"
 
 # Check retry parameters
-# api_retry_max must be 0-10
-# api_retry_delay must be 0.1-60
+# tn_api_retry_max must be 0-10
+# tn_api_retry_delay must be 0.1-60
 
 # Verify all required parameters present:
-# - api_host
-# - api_key
-# - dataset
-# - target_iqn
-# - discovery_portal
+# - tn_api_host
+# - tn_api_key
+# - tn_dataset
+# - tn_target_iqn
+# - tn_discovery_portal
 ```
 
 ## Updating the Plugin

--- a/wiki/Known-Limitations.md
+++ b/wiki/Known-Limitations.md
@@ -336,18 +336,20 @@ shared 1
 
 ### vmstate Storage Considerations
 
-**Limitation**: Live migration with existing snapshots requires `vmstate_storage shared`
+**Limitation**: Live migration with existing snapshots requires vmstate to be reachable from the target node.
 
 **Explanation**:
 - If VM has snapshots with vmstate on local storage
 - Live migration fails (vmstate not accessible from target node)
 
+> ⚠️ `tn_vmstate_storage` is not currently implemented by this plugin (see [Configuration Reference](Configuration.md#tn_vmstate_storage)) — vmstate placement is controlled entirely by Proxmox core, not by this setting.
+
 **Workaround**:
 ```ini
-# Use shared vmstate for environments requiring migration
-tn_vmstate_storage shared
+# Use shared storage for vmstate in environments requiring migration
+# (configure via Proxmox's own vmstate storage selection, not this plugin)
 
-# Or use local vmstate and delete snapshots before migration
+# Or delete snapshots before migration
 # Or use offline migration (stop VM, migrate, start)
 ```
 
@@ -465,7 +467,7 @@ nfs: truenas-files
 **Required Settings**:
 ```ini
 tn_prefer_ipv4 0
-tn_ipv6_by_path 1
+tn_ipv6_by_path 1  # not currently implemented, see Configuration.md#tn_ipv6_by_path
 tn_use_by_path 1
 ```
 

--- a/wiki/NVMe-Setup.md
+++ b/wiki/NVMe-Setup.md
@@ -55,9 +55,9 @@ This guide covers setting up NVMe over TCP (NVMe/TCP) storage with the TrueNAS P
 
 2. **Via TrueNAS API (plugin call):**
    ```bash
-   ssh root@PROXMOX_NODE "perl -e 'use lib \"/usr/share/perl5\"; use PVE::Storage; use PVE::Storage::Custom::TrueNASPlugin; my $scfg=PVE::Storage::config()->{ids}{\"STORAGE_ID\"} or die \"storage STORAGE_ID not found\\n\"; my $res=PVE::Storage::Custom::TrueNASPlugin::_api_call_write($scfg, \"service.update\", [\"nvmet\", { enable => 1 }]); print \"ok\\n\";'"
+   ssh root@PROXMOX_NODE "perl -e 'use lib \"/usr/share/perl5\"; use PVE::Storage; use PVE::Storage::Custom::TrueNASPlugin; my $scfg=PVE::Storage::config()->{ids}{\"STORAGE_ID\"} or die \"storage STORAGE_ID not found\\n\"; my $res=PVE::Storage::Custom::TrueNASPlugin::_api_call_mutate($scfg, \"service.update\", [\"nvmet\", { enable => 1 }]); print \"ok\\n\";'"
 
-   ssh root@PROXMOX_NODE "perl -e 'use lib \"/usr/share/perl5\"; use PVE::Storage; use PVE::Storage::Custom::TrueNASPlugin; my $scfg=PVE::Storage::config()->{ids}{\"STORAGE_ID\"} or die \"storage STORAGE_ID not found\\n\"; my $res=PVE::Storage::Custom::TrueNASPlugin::_api_call_write($scfg, \"service.start\", [\"nvmet\"]); print \"ok\\n\";'"
+   ssh root@PROXMOX_NODE "perl -e 'use lib \"/usr/share/perl5\"; use PVE::Storage; use PVE::Storage::Custom::TrueNASPlugin; my $scfg=PVE::Storage::config()->{ids}{\"STORAGE_ID\"} or die \"storage STORAGE_ID not found\\n\"; my $res=PVE::Storage::Custom::TrueNASPlugin::_api_call_mutate($scfg, \"service.start\", [\"nvmet\"]); print \"ok\\n\";'"
    ```
 
 3. **Verify service is running:**
@@ -84,7 +84,7 @@ The plugin automatically creates subsystems when needed, but you can create them
 
 2. **Via TrueNAS API (plugin call):**
    ```bash
-   ssh root@PROXMOX_NODE "perl -e 'use lib \"/usr/share/perl5\"; use PVE::Storage; use PVE::Storage::Custom::TrueNASPlugin; my $scfg=PVE::Storage::config()->{ids}{\"STORAGE_ID\"} or die \"storage STORAGE_ID not found\\n\"; my $res=PVE::Storage::Custom::TrueNASPlugin::_api_call_write($scfg, \"nvmet.subsys.create\", [{ name => \"proxmox-nvme\", subnqn => \"nqn.2005-10.org.freenas.ctl:proxmox-nvme\", allow_any_host => 1 }]); print \"ok\\n\";'"
+   ssh root@PROXMOX_NODE "perl -e 'use lib \"/usr/share/perl5\"; use PVE::Storage; use PVE::Storage::Custom::TrueNASPlugin; my $scfg=PVE::Storage::config()->{ids}{\"STORAGE_ID\"} or die \"storage STORAGE_ID not found\\n\"; my $res=PVE::Storage::Custom::TrueNASPlugin::_api_call_mutate($scfg, \"nvmet.subsys.create\", [{ name => \"proxmox-nvme\", subnqn => \"nqn.2005-10.org.freenas.ctl:proxmox-nvme\", allow_any_host => 1 }]); print \"ok\\n\";'"
    ```
 
 **Important Notes:**
@@ -324,7 +324,7 @@ Configure host authentication on TrueNAS:
 
 **Via TrueNAS API (plugin call):**
 ```bash
-ssh root@PROXMOX_NODE "perl -e 'use lib \"/usr/share/perl5\"; use PVE::Storage; use PVE::Storage::Custom::TrueNASPlugin; my $scfg=PVE::Storage::config()->{ids}{\"STORAGE_ID\"} or die \"storage STORAGE_ID not found\\n\"; my $res=PVE::Storage::Custom::TrueNASPlugin::_api_call_write($scfg, \"nvmet.host.create\", [{ hostnqn => \"nqn.2014-08.org.nvmexpress:uuid:81d0b800-0d47-11ea-a719-d0fedbf91400\", dhchap_key => \"DHHC-1:01:l29rbM7waP9bX4gjmx0e6S6eK5sDb7a5c0jZJG2XxcwvDbY0:\", dhchap_ctrl_key => \"DHHC-1:01:6Fk0dLGH1uPYPVKlyTNOWf4dk8FNOs9abL1p4cT0Qq2yEXLq:\", dhchap_hash => \"SHA-256\" }]); print \"ok\\n\";'"
+ssh root@PROXMOX_NODE "perl -e 'use lib \"/usr/share/perl5\"; use PVE::Storage; use PVE::Storage::Custom::TrueNASPlugin; my $scfg=PVE::Storage::config()->{ids}{\"STORAGE_ID\"} or die \"storage STORAGE_ID not found\\n\"; my $res=PVE::Storage::Custom::TrueNASPlugin::_api_call_mutate($scfg, \"nvmet.host.create\", [{ hostnqn => \"nqn.2014-08.org.nvmexpress:uuid:81d0b800-0d47-11ea-a719-d0fedbf91400\", dhchap_key => \"DHHC-1:01:l29rbM7waP9bX4gjmx0e6S6eK5sDb7a5c0jZJG2XxcwvDbY0:\", dhchap_ctrl_key => \"DHHC-1:01:6Fk0dLGH1uPYPVKlyTNOWf4dk8FNOs9abL1p4cT0Qq2yEXLq:\", dhchap_hash => \"SHA-256\" }]); print \"ok\\n\";'"
 ```
 
 **Parameters:**
@@ -339,7 +339,7 @@ To restrict access to specific hosts, disable `allow_any_host` and create host-s
 
 ```bash
 # Step 1: Disable allow_any_host on the subsystem
-ssh root@PROXMOX_NODE "perl -e 'use lib \"/usr/share/perl5\"; use PVE::Storage; use PVE::Storage::Custom::TrueNASPlugin; my $scfg=PVE::Storage::config()->{ids}{\"STORAGE_ID\"} or die \"storage STORAGE_ID not found\\n\"; my $res=PVE::Storage::Custom::TrueNASPlugin::_api_call_write($scfg, \"nvmet.subsys.update\", [\"SUBSYS_ID\", { allow_any_host => 0 }]); print \"ok\\n\";'"
+ssh root@PROXMOX_NODE "perl -e 'use lib \"/usr/share/perl5\"; use PVE::Storage; use PVE::Storage::Custom::TrueNASPlugin; my $scfg=PVE::Storage::config()->{ids}{\"STORAGE_ID\"} or die \"storage STORAGE_ID not found\\n\"; my $res=PVE::Storage::Custom::TrueNASPlugin::_api_call_mutate($scfg, \"nvmet.subsys.update\", [\"SUBSYS_ID\", { allow_any_host => 0 }]); print \"ok\\n\";'"
 
 # Step 2: Get the host ID (query existing hosts)
 ssh root@PROXMOX_NODE "perl -e 'use lib \"/usr/share/perl5\"; use PVE::Storage; use PVE::Storage::Custom::TrueNASPlugin; my $scfg=PVE::Storage::config()->{ids}{\"STORAGE_ID\"} or die \"storage STORAGE_ID not found\\n\"; my $res=PVE::Storage::Custom::TrueNASPlugin::_api_call($scfg, \"nvmet.host.query\", [[]]); print \"ok\\n\";'"
@@ -350,7 +350,7 @@ ssh root@PROXMOX_NODE "perl -e 'use lib \"/usr/share/perl5\"; use PVE::Storage; 
 # Returns: [{"id": 1, "name": "proxmox-nvme", "subnqn": "nqn.2005-10.org.freenas.ctl:proxmox-nvme", ...}]
 
 # Step 4: Link the host to the subsystem
-ssh root@PROXMOX_NODE "perl -e 'use lib \"/usr/share/perl5\"; use PVE::Storage; use PVE::Storage::Custom::TrueNASPlugin; my $scfg=PVE::Storage::config()->{ids}{\"STORAGE_ID\"} or die \"storage STORAGE_ID not found\\n\"; my $res=PVE::Storage::Custom::TrueNASPlugin::_api_call_write($scfg, \"nvmet.host_subsys.create\", [{ host_id => 1, subsys_id => 1 }]); print \"ok\\n\";'"
+ssh root@PROXMOX_NODE "perl -e 'use lib \"/usr/share/perl5\"; use PVE::Storage; use PVE::Storage::Custom::TrueNASPlugin; my $scfg=PVE::Storage::config()->{ids}{\"STORAGE_ID\"} or die \"storage STORAGE_ID not found\\n\"; my $res=PVE::Storage::Custom::TrueNASPlugin::_api_call_mutate($scfg, \"nvmet.host_subsys.create\", [{ host_id => 1, subsys_id => 1 }]); print \"ok\\n\";'"
 ```
 
 **Important**: When `allow_any_host: false`, ONLY explicitly linked hosts can connect to the subsystem. DH-CHAP authentication is an optional additional security layer.

--- a/wiki/README.md
+++ b/wiki/README.md
@@ -64,7 +64,7 @@ Official wiki home: <https://github.com/truenas/truenas-proxmox-plugin/wiki>
 
 **Configuration**:
 - [Required Parameters](Configuration.md#required-parameters)
-- [Basic Configuration Example](Configuration.md#basic-single-node-configuration)
+- [Basic Configuration Example](Configuration.md#basic-single-node-configuration-iscsi)
 - [Production Cluster Example](Configuration.md#production-cluster-configuration)
 
 **Troubleshooting**:

--- a/wiki/Troubleshooting.md
+++ b/wiki/Troubleshooting.md
@@ -499,9 +499,9 @@ tn_api_scheme ws   # for insecure WebSocket (testing only)
 
 # Common mistake: Using http/https scheme instead of ws/wss
 # WRONG:
-# api_scheme https  # Not supported
+# tn_api_scheme https  # Not supported
 # CORRECT:
-# api_scheme wss    # This is for WebSocket
+# tn_api_scheme wss    # This is for WebSocket
 ```
 
 #### 6. Check WebSocket Port Configuration
@@ -1191,8 +1191,8 @@ ssh root@PROXMOX_NODE "perl -e 'use lib \"/usr/share/perl5\"; use PVE::Storage; 
 nano /etc/pve/storage.cfg
 
 # Comment out secrets:
-# nvme_dhchap_secret DHHC-1:01:...
-# nvme_dhchap_ctrl_secret DHHC-1:01:...
+# tn_nvme_dhchap_secret DHHC-1:01:...
+# tn_nvme_dhchap_ctrl_secret DHHC-1:01:...
 
 # Set subsystem allow_any_host = true in TrueNAS
 

--- a/wiki/Troubleshooting.md
+++ b/wiki/Troubleshooting.md
@@ -1028,7 +1028,7 @@ ssh root@PROXMOX_NODE "perl -e 'use lib \"/usr/share/perl5\"; use PVE::Storage; 
 # Should return ok if the call succeeds
 
 # Start service if not running using plugin API via STORAGE_ID
-ssh root@PROXMOX_NODE "perl -e 'use lib \"/usr/share/perl5\"; use PVE::Storage; use PVE::Storage::Custom::TrueNASPlugin; my $scfg=PVE::Storage::config()->{ids}{\"STORAGE_ID\"} or die \"storage STORAGE_ID not found\\n\"; my $res=PVE::Storage::Custom::TrueNASPlugin::_api_call_write($scfg, \"service.start\", [\"nvmet\"]); print \"ok\\n\";'"
+ssh root@PROXMOX_NODE "perl -e 'use lib \"/usr/share/perl5\"; use PVE::Storage; use PVE::Storage::Custom::TrueNASPlugin; my $scfg=PVE::Storage::config()->{ids}{\"STORAGE_ID\"} or die \"storage STORAGE_ID not found\\n\"; my $res=PVE::Storage::Custom::TrueNASPlugin::_api_call_mutate($scfg, \"service.start\", [\"nvmet\"]); print \"ok\\n\";'"
 ```
 
 In TrueNAS Web UI:


### PR DESCRIPTION
## Summary

Docs-only audit triggered by #72 (NVMe setup docs calling a function that no longer exists). Turned up several more instances of the same underlying problem — wiki content that wasn't updated when the code it describes changed.

## Changes

**#72 itself**: `_api_call_write()` was renamed to `_api_call_mutate()` in commit `d245787`. `NVMe-Setup.md` (6 places) and `Troubleshooting.md` (1 place) still told users to call the old name — every copy-pasted diagnostic one-liner in those docs would die immediately with "Undefined subroutine."

**Removed API namespace**: `API-Reference.md` documented `zfs.snapshot.*` as the live snapshot API (6 places). TrueNAS 25.10 removed that namespace entirely in favor of `pool.snapshot.*` — the plugin's own Changelog already documents this rename, the API reference just never caught up.

**Connection architecture rewrite**: `Advanced-Features.md` and `API-Reference.md` described a per-write ephemeral-connection model (`_ws_open_ephemeral()`/`_ws_close_ephemeral()`) that no longer exists — mutations now share the same connection routing as reads (`_api_call_mutate` is a thin alias for `_api_call`, per commit `d245787`'s own message). Neither doc mentioned the broker daemon at all, despite it being the plugin's preferred connection path today. Rewrote both sections to describe broker vs. direct mode accurately.

**Dead config keys flagged**: `tn_enable_live_snapshots`, `tn_snapshot_volume_chains`, `tn_vmstate_storage`, and `tn_ipv6_by_path` are declared in the plugin's option schema and fully documented with worked examples, but are never read anywhere else in the plugin — setting them has no effect. Flagged with ⚠️ at every occurrence across `Configuration.md`, `Advanced-Features.md`, and `Known-Limitations.md` rather than silently deleted, since I don't know whether the intent is to finish the wiring or drop the keys.

**Missing live keys added**: `tn_compression`, `tn_device_ready_retries`, and `tn_nr_io_queues` are functional, schema-declared options that were simply never added to `Configuration.md`.

**Broken TOC**: `Configuration.md`'s Table of Contents used pre-2.1.0 unprefixed anchor links (`#api_host`, `#zvol_blocksize`, etc.) that didn't match the actual `tn_`-prefixed headings — rebuilt against the real heading set. Fixed two matching broken cross-references in `Advanced-Features.md` and `wiki/README.md`.

**Bare-key examples elsewhere**: `Installation.md`'s "storage configuration rejected" troubleshooting block, and two WRONG/CORRECT examples in `Troubleshooting.md`, used pre-2.1.0 bare key names — the same class of mistake behind issues #62/#65/#66.

**D2-per-process-reauth.md status note**: this design doc framed the session broker as a proposed fix living on a separate `broker-service` branch. It's since been merged directly into `TrueNASPlugin.pm` (commit `b9c47d3`); added a status callout so the rest of the doc's present-tense broker descriptions aren't misread as hypothetical.

## Not in scope

Filed separately as #73: `tn_broker_timeout` is read by the plugin but isn't declared in the option schema, so it can't actually be set via `storage.cfg` — that's a code fix, not a docs fix.