### PR TITLE
truenas-plugin-broker: fix hardcoded WS path pin (#66)

### DIFF
--- a/tools/truenas-plugin-broker
+++ b/tools/truenas-plugin-broker
@@ -42,7 +42,7 @@ my $SOCKET_PATH    = '/run/truenas-plugin/broker.sock';
 my $PIDFILE        = '/run/truenas-plugin/broker.pid';
 my $LOG_FILE       = '/var/log/truenas-plugin-broker.log';
 my $IDLE_REAP_SECS = 600;   # close WS conns idle longer than this
-my $WS_PINNED_PATH = '/api/v25.10.2';
+my $WS_PATH = '/api/current';
 
 my $foreground = grep { $_ eq '--foreground' || $_ eq '-f' } @ARGV;
 my $debug      = grep { $_ eq '--debug' || $_ eq '-d' } @ARGV;
@@ -115,7 +115,7 @@ sub ws_open {
     my $key_raw = join '', map { chr(int(rand(256))) } 1..16;
     my $key_b64 = encode_base64($key_raw, '');
     my $req =
-      "GET $WS_PINNED_PATH HTTP/1.1\r\n".
+      "GET $WS_PATH HTTP/1.1\r\n".
       "Host: $host:$port\r\n".
       "Upgrade: websocket\r\n".
       "Connection: Upgrade\r\n".


### PR DESCRIPTION
## Summary
- `$WS_PINNED_PATH` in `tools/truenas-plugin-broker` was hardcoded to `/api/v25.10.2`, which 404s (no HTTP 101) on any TrueNAS build that doesn't ship that exact API version directory — causing `pvesm status` to report the storage as `inactive`.
- Switched to `/api/current`, matching `TrueNASPlugin.pm`'s direct-mode connection, and avoiding the `LegacyAPIMethod` version-translation layer the plugin's payloads were never written against.

Fixes #66 (broker WS handshake failure reported by tomtom0013, elmemis).

## Test plan
- [x] Reproduced the exact failure on the test cluster by pinning to a version the connected build doesn't have (`/api/v25.10.4` against a 25.10.2.1 host)
- [x] Applied fix, restarted broker, confirmed WS handshake succeeds and `pvesm status` returns both storages to `active` with correct capacity