### PR TITLE
Fix pool.dataset.create _NotRequired crash on TrueNAS 25.10.4 (#58, #65, #78)

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,6 @@ This project is provided as-is for use with Proxmox VE and TrueNAS SCALE.
 
 ---
 
-**Version**: 2.1.5
-**Last Updated**: June 16, 2026
+**Version**: 2.1.20
+**Last Updated**: July 18, 2026
 **Compatibility**: Proxmox VE 8.x+, TrueNAS SCALE 25.10+

--- a/TrueNASPlugin.pm
+++ b/TrueNASPlugin.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 
 # Plugin Version
-our $VERSION = '2.1.5';
+our $VERSION = '2.1.20';
 # Highest Proxmox storage API version this plugin is validated against.
 our $TESTED_APIVER = 14;
 use JSON::PP qw(encode_json decode_json);
@@ -1699,16 +1699,23 @@ sub _tn_pool_health($scfg) {
 # PVE passes size in KiB; TrueNAS expects bytes (volsize) and supports 'sparse'
 sub _tn_dataset_create($scfg, $full, $size_kib, $blocksize) {
     my $bytes = int($size_kib) * 1024;
+    # All six of these must be sent explicitly, not omitted: TrueNAS 25.10.4's
+    # legacy API shim leaves omitted optional fields as unresolved _NotRequired
+    # sentinels instead of real defaults, crashing pool.dataset.create both in
+    # validation and in audit-log serialization (#58, #65, #78). special_small_block_size
+    # must be 'INHERIT' specifically - 0 fails a ZFS-level check, null fails Pydantic.
     my $payload = {
-        name   => $full,
-        type   => 'VOLUME',
-        volsize=> $bytes,
-        sparse => ($scfg->{tn_sparse} // 1) ? JSON::PP::true : JSON::PP::false,
+        name                     => $full,
+        type                     => 'VOLUME',
+        volsize                  => $bytes,
+        sparse                   => ($scfg->{tn_sparse} // 1) ? JSON::PP::true : JSON::PP::false,
+        volblocksize             => _normalize_blocksize($blocksize) // '16K',
+        snapdev                  => 'INHERIT',
+        reservation              => 0,
+        refreservation           => 0,
+        special_small_block_size => 'INHERIT',
+        force_size               => JSON::PP::false,
     };
-    # Normalize blocksize to uppercase for TrueNAS 25.10+ compatibility
-    if ($blocksize) {
-        $payload->{volblocksize} = _normalize_blocksize($blocksize);
-    }
     my $result = _api_call_mutate($scfg, 'pool.dataset.create', [ $payload ]);
     _invalidate_status_capacity_cache(undef, $scfg);
     return $result;
@@ -4537,15 +4544,24 @@ sub alloc_image {
         $create_attempt++;
         $create_error = undef;
 
+        # All six of these must be sent explicitly, not omitted: TrueNAS 25.10.4's
+        # legacy API shim leaves omitted optional fields as unresolved _NotRequired
+        # sentinels instead of real defaults, crashing pool.dataset.create both in
+        # validation and in audit-log serialization (#58, #65, #78). special_small_block_size
+        # must be 'INHERIT' specifically - 0 fails a ZFS-level check, null fails Pydantic.
         my $create_payload = {
-            name     => $full_ds,
-            type     => 'VOLUME',
-            volsize  => $bytes,
-            sparse   => ($scfg->{tn_sparse} // 1) ? JSON::PP::true : JSON::PP::false,
-            comments => 'Autocreated by Proxmox Plugin',
+            name                     => $full_ds,
+            type                     => 'VOLUME',
+            volsize                  => $bytes,
+            sparse                   => ($scfg->{tn_sparse} // 1) ? JSON::PP::true : JSON::PP::false,
+            comments                 => 'Autocreated by Proxmox Plugin',
+            volblocksize             => _normalize_blocksize($blocksize) // '16K',
+            snapdev                  => 'INHERIT',
+            reservation              => 0,
+            refreservation           => 0,
+            special_small_block_size => 'INHERIT',
+            force_size               => JSON::PP::false,
         };
-        # Normalize blocksize to uppercase for TrueNAS 25.10+ compatibility
-        $create_payload->{volblocksize} = _normalize_blocksize($blocksize) if $blocksize;
         # Pass compression algorithm if configured (otherwise inherits from parent dataset)
         $create_payload->{compression} = uc($scfg->{tn_compression}) if $scfg->{tn_compression};
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,25 @@
+truenas-proxmox-plugin (2.1.20+deb1) unstable; urgency=high
+
+  * Fix pool.dataset.create crash on TrueNAS 25.10.4 (#58, #65, #78).
+    Both create call sites (_tn_dataset_create and alloc_image's inline
+    payload) omitted six optional fields: volblocksize (when
+    tn_zvol_blocksize was unset), snapdev, reservation, refreservation,
+    special_small_block_size, force_size. TrueNAS 25.10.4's legacy API
+    shim leaves omitted optional fields as unresolved _NotRequired
+    sentinel objects instead of real defaults, which crashes
+    pool.dataset.create both during validation (dataset.py's
+    __common_validation and do_create) and, even when validation
+    passes, during audit-log JSON serialization afterward - the latter
+    masks a create that actually succeeded server-side, leaving an
+    orphaned zvol while Proxmox reports total failure. All six fields
+    are now sent explicitly at both call sites. special_small_block_size
+    is set to 'INHERIT' specifically: 0 fails a ZFS-level check ("does
+    not apply to datasets of this type"), null fails the Pydantic
+    schema check, INHERIT satisfies both, consistent with how every
+    other inheritable property in the payload is already handled.
+
+ -- TrueNAS Proxmox Plugin Maintainers <noreply@github.com>  Sat, 18 Jul 2026 00:00:00 +0000
+
 truenas-proxmox-plugin (2.1.17+deb1) unstable; urgency=high
 
   * Template / linked-clone support (plan C). Implements the PVE

--- a/wiki/Changelog.md
+++ b/wiki/Changelog.md
@@ -1,5 +1,11 @@
 # TrueNAS Plugin Changelog
 
+## Version 2.1.20 (July 18, 2026)
+
+### Bug Fixes
+
+- **Fix `pool.dataset.create` crash on TrueNAS 25.10.4 (#58, #65, #78)**: Both dataset-create call sites (`_tn_dataset_create` and `alloc_image`'s inline payload) omitted six optional fields — `volblocksize` (when `tn_zvol_blocksize` was unset), `snapdev`, `reservation`, `refreservation`, `special_small_block_size`, `force_size`. TrueNAS 25.10.4's legacy API compatibility shim leaves omitted optional fields as unresolved `_NotRequired` sentinel objects instead of real defaults, which crashes `pool.dataset.create` — either during validation, or, even when validation passes, during audit-log JSON serialization afterward. The latter case is especially disruptive: it masks a create that actually succeeded server-side, leaving an orphaned zvol on TrueNAS while Proxmox reports total failure. All six fields are now sent explicitly at both call sites. `special_small_block_size` must be `'INHERIT'` specifically — `0` fails a ZFS-level check ("does not apply to datasets of this type"), `null` fails the Pydantic schema check, and `INHERIT` satisfies both, consistent with how every other inheritable property in the payload is already handled.
+
 ## Version 2.1.5 (June 16, 2026)
 
 ### Bug Fixes

--- a/wiki/README.md
+++ b/wiki/README.md
@@ -170,6 +170,6 @@ For issues not covered in documentation:
 
 ## Version Information
 
-**Version**: 2.1.5
-**Last Updated**: June 16, 2026
+**Version**: 2.1.20
+**Last Updated**: July 18, 2026
 **Compatibility**: Proxmox VE 8.x+, TrueNAS SCALE 25.10+


### PR DESCRIPTION
## Summary
- Both dataset-create call sites (`_tn_dataset_create()` and `alloc_image()`'s inline payload) omitted six optional `pool.dataset.create` fields: `volblocksize` (when `tn_zvol_blocksize` was unset), `snapdev`, `reservation`, `refreservation`, `special_small_block_size`, `force_size`.
- On TrueNAS 25.10.4, the legacy API shim leaves omitted optional fields as unresolved `_NotRequired` sentinel objects instead of real defaults. This crashes `pool.dataset.create` either during validation, or (even when validation passes) during audit-log JSON serialization afterward, which masks a create that actually succeeded server-side and leaves an orphaned zvol while Proxmox reports total failure.
- All six fields are now sent explicitly at both call sites. `special_small_block_size` must be `'INHERIT'` specifically: `0` fails a ZFS-level check ("does not apply to datasets of this type"), `null` fails the Pydantic schema check, `INHERIT` satisfies both.
- Fixes #58, #65, #78.

## Verification
- Verified via TrueNAS `audit.query` that the real payload sent by the plugin now includes all six fields on both iSCSI and NVMe-TCP transports.
- Directly invoked the fixed `_tn_dataset_create()` with `blocksize=undef` (i.e. `tn_zvol_blocksize` unset) against a test TrueNAS, confirmed `volblocksize` now resolves to `16K` instead of being omitted from the payload.
- Could not reproduce the original crash on our test cluster (TrueNAS 25.10.2.1, the bug is specific to 25.10.4's legacy API shim behavior). `@morganhjk` confirmed the fix via the A/B repro script on 25.10.4 (issuecomment-5014978017).